### PR TITLE
Bugfix/js/deep nested arrays

### DIFF
--- a/packages/js/spec/getObjectField.spec.ts
+++ b/packages/js/spec/getObjectField.spec.ts
@@ -28,6 +28,11 @@ describe('getObjectField', () => {
     expect(getObjectField(object, 'items.price')).to.deep.equal([12, 14])
   })
 
+  it('returns property values from nested array as flat array', () => {
+    const object = { items: [{ specs: [{ price: 12 }] }, { specs: [{ price: 14 }] }] }
+    expect(getObjectField(object, 'items.specs.price')).to.deep.equal([12, 14])
+  })
+
   it('returns array item when specified number as the last path field', () => {
     const object = { items: [{ price: 12 }, { price: 14 }] }
     expect(getObjectField(object, 'items.0')).to.deep.equal({ price: 12 })

--- a/packages/js/spec/interpreters.spec.ts
+++ b/packages/js/spec/interpreters.spec.ts
@@ -321,6 +321,7 @@ describe('Condition Interpreter', () => {
       const condition = new Field('size', 'items.a', 2)
 
       expect(interpret(condition, { items: [{ a: [2, 3] }, { a: [] }, {}] })).to.be.true
+      expect(interpret(condition, { items: [{ a: [2, 3] }, { a: [4] }, {}] })).to.be.true
       expect(interpret(condition, { items: [5, 4] })).to.be.false
       expect(interpret(condition, { items: { a: [2, 3] } })).to.be.true
     })

--- a/packages/js/spec/interpreters.spec.ts
+++ b/packages/js/spec/interpreters.spec.ts
@@ -321,7 +321,7 @@ describe('Condition Interpreter', () => {
       const condition = new Field('size', 'items.a', 2)
 
       expect(interpret(condition, { items: [{ a: [2, 3] }, { a: [] }, {}] })).to.be.true
-      expect(interpret(condition, { items: [{ a: [2, 3] }, { a: [4] }, {}] })).to.be.true
+      expect(interpret(condition, { items: [{ a: [2, 3] }, { a: [4] }, { a: [2] }] })).to.be.true
       expect(interpret(condition, { items: [5, 4] })).to.be.false
       expect(interpret(condition, { items: { a: [2, 3] } })).to.be.true
     })
@@ -362,7 +362,7 @@ describe('Condition Interpreter', () => {
       const condition = new DocumentCondition('where', () => true)
 
       expect(interpret(condition, {})).to.be.true
-      expect(interpret(condition, (null as unknown) as Record<PropertyKey, unknown>)).to.be.true
+      expect(interpret(condition, null as unknown as Record<PropertyKey, unknown>)).to.be.true
     })
 
     it('binds passed in object as "this"', () => {
@@ -490,9 +490,9 @@ describe('Condition Interpreter', () => {
 
       expect(interpret(condition, { items: [] })).to.be.false
       expect(interpret(condition, { items: [{ prices: [1, 2] }] })).to.be.false
-      expect(interpret(condition, { items: [{ prices: [1, 2, 3] }] })).to.be.true
-      expect(interpret(condition, { items: [{ names: ['test'] }, { prices: [1, 2, 3] }] })).to.be
-        .true
+      expect(interpret(condition, { items: [{ prices: condition.value }] })).to.be.true
+      expect(interpret(condition, { items: [{ names: ['test'] }, { prices: condition.value }] }))
+        .to.be.true
     })
   })
 

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -1,5 +1,4 @@
 export * from './interpreters';
 export * from './interpreter';
 export * from './defaults';
-export { PROJECTED_FIELD } from './utils';
 export type { JsInterpretationOptions, JsInterpreter } from './types';

--- a/packages/js/src/interpreter.ts
+++ b/packages/js/src/interpreter.ts
@@ -5,6 +5,19 @@ import { JsInterpretationOptions, JsInterpreter } from './types';
 const defaultGet = (object: AnyObject, field: string) => object[field];
 type Field = string | typeof ITSELF;
 
+export function getObjectFieldCursor<T extends {}>(object: T, path: string, get: GetField) {
+  const dotIndex = path.lastIndexOf('.');
+
+  if (dotIndex === -1) {
+    return [object, path] as const;
+  }
+
+  return [
+    get(object, path.slice(0, dotIndex)) as T,
+    path.slice(dotIndex + 1)
+  ] as const;
+}
+
 export function getObjectField(object: unknown, field: Field, get: GetField = defaultGet) {
   if (field === ITSELF) {
     return object;

--- a/packages/js/src/interpreters.ts
+++ b/packages/js/src/interpreters.ts
@@ -13,6 +13,7 @@ import {
   isArrayAndNotNumericField,
   AnyObject,
 } from './utils';
+import { getObjectFieldCursor } from './interpreter';
 
 export const or: Interpret<Compound> = (node, object, { interpret }) => {
   return node.value.some(condition => interpret(condition, object));
@@ -65,15 +66,8 @@ export const exists: Interpret<Field<boolean>> = (node, object, { get }) => {
     return typeof object !== 'undefined';
   }
 
-  let item = object;
-  let field = node.field;
-  const dotIndex = node.field.lastIndexOf('.');
+  const [item, field] = getObjectFieldCursor<{}>(object, node.field, get);
   const test = (value: {}) => !!value && value.hasOwnProperty(field) === node.value;
-
-  if (dotIndex !== -1) {
-    field = node.field.slice(dotIndex + 1);
-    item = get(object, node.field.slice(0, dotIndex));
-  }
 
   return isArrayAndNotNumericField(item, field) ? item.some(test) : test(item);
 };
@@ -83,43 +77,33 @@ export const mod = testValueOrArray<[number, number], number>((node, value) => {
 });
 
 export const size: Interpret<Field<number>, AnyObject | unknown[]> = (node, object, { get }) => {
-  const value = get(object, node.field);
+  const [items, field] = getObjectFieldCursor(object as AnyObject, node.field, get);
+  const test = (item: unknown) => {
+    const value = get(item, field);
+    return Array.isArray(value) && value.length === node.value;
+  };
 
-  if (!Array.isArray(value)) {
-    return false;
-  }
-
-  return value.length === node.value;
+  return node.field !== ITSELF && isArrayAndNotNumericField(items, field)
+    ? items.some(test)
+    : test(items);
 };
 
 export const regex = testValueOrArray<RegExp, string>((node, value) => node.value.test(value));
 
-export const within: Interpret<Field<unknown[]>> = testValueOrArray(
-  (node, object, { equal }) => includes(node.value, object, equal)
-);
+export const within = testValueOrArray<unknown[], unknown>((node, object, { equal }) => {
+  return includes(node.value, object, equal);
+});
 
-export const nin: typeof within = (node, object, context) => {
-  return !within(node, object, context);
-};
+export const nin: typeof within = (node, object, context) => !within(node, object, context);
 
 export const all: Interpret<Field<unknown[]>> = (node, object, { equal, get }) => {
   const value = get(object, node.field);
-
-  if (!Array.isArray(value)) {
-    return false;
-  }
-
-  return node.value.every(v => includes(value, v, equal));
+  return Array.isArray(value) && node.value.every(v => includes(value, v, equal));
 };
 
 export const elemMatch: Interpret<Field<Condition>> = (node, object, { interpret, get }) => {
   const value = get(object, node.field);
-
-  if (!Array.isArray(value)) {
-    return false;
-  }
-
-  return value.some(v => interpret(node.value, v));
+  return Array.isArray(value) && value.some(v => interpret(node.value, v));
 };
 
 type WhereFunction = (this: AnyObject) => boolean;

--- a/packages/js/src/utils.ts
+++ b/packages/js/src/utils.ts
@@ -4,7 +4,11 @@ import { JsInterpretationOptions, JsInterpreter } from './types';
 export type AnyObject = Record<PropertyKey, unknown>;
 export type GetField = (object: any, field: string) => any;
 
-export function includes<T>(items: T[], value: T, equal: JsInterpretationOptions['equal']): boolean {
+export function includes<T>(
+  items: T[],
+  value: T,
+  equal: JsInterpretationOptions['equal']
+): boolean {
   for (let i = 0, length = items.length; i < length; i++) {
     if (equal(items[i], value)) {
       return true;
@@ -14,16 +18,16 @@ export function includes<T>(items: T[], value: T, equal: JsInterpretationOptions
   return false;
 }
 
-export const PROJECTED_FIELD = typeof Symbol === 'undefined' ? '__projected' : Symbol('projected');
-
 export function isArrayAndNotNumericField<T>(object: T | T[], field: string): object is T[] {
   return Array.isArray(object) && Number.isNaN(Number(field));
 }
 
 function getField<T extends AnyObject>(object: T | T[], field: string, get: GetField) {
   if (isArrayAndNotNumericField(object, field)) {
-    const items = object.map(item => get(item, field));
-    return Object.defineProperty(items, PROJECTED_FIELD, { value: true });
+    return object.reduce((acc, item) => {
+      const value = get(item, field);
+      return value !== undefined ? acc.concat(value) : acc;
+    }, []);
   }
 
   return get(object, field);


### PR DESCRIPTION
It modify the `getField` function in order to works with deeply nested arrays of objects and output a flat array of items.

This also helps interpreters to validate items without having to loop through nested arrays.

It removes the `PROJECTED_FIELD` const and its export as it's not needed anymore.

And it refactor the `within` interpreter by using `testValueOrArray`, the `size` one by removing the projected_field check and the `all` one by reordering the array check.

It also adds tests to be sure that getting and checking deeply nested arrays of objects works.