### PR TITLE
Bugfix/js/regex with undefined value

### DIFF
--- a/packages/js/spec/interpreters.spec.ts
+++ b/packages/js/spec/interpreters.spec.ts
@@ -353,6 +353,14 @@ describe('Condition Interpreter', () => {
       expect(interpret(condition, item('ucast@github.com'))).to.be.true
       expect(interpret(condition, item('some text'))).to.be.false
     })
+
+    it('return false if key doesn\'t exist or if value is undefined', () => {
+      const condition = new Field('regex', 'email', /i/)
+
+      expect(interpret(condition, { email: 'ucast@github.com', })).to.be.true
+      expect(interpret(condition, { email: undefined, })).to.be.false
+      expect(interpret(condition, {})).to.be.false
+    })
   })
 
   describe('where', () => {

--- a/packages/js/spec/interpreters.spec.ts
+++ b/packages/js/spec/interpreters.spec.ts
@@ -354,11 +354,12 @@ describe('Condition Interpreter', () => {
       expect(interpret(condition, item('some text'))).to.be.false
     })
 
-    it('return false if key doesn\'t exist or if value is undefined', () => {
+    it('return false if key is `undefined` or `null`', () => {
       const condition = new Field('regex', 'email', /i/)
 
       expect(interpret(condition, { email: 'ucast@github.com', })).to.be.true
       expect(interpret(condition, { email: undefined, })).to.be.false
+      expect(interpret(condition, { email: null, })).to.be.false
       expect(interpret(condition, {})).to.be.false
     })
   })

--- a/packages/js/src/interpreters.ts
+++ b/packages/js/src/interpreters.ts
@@ -73,7 +73,7 @@ export const exists: Interpret<Field<boolean>> = (node, object, { get }) => {
 };
 
 export const mod = testValueOrArray<[number, number], number>((node, value) => {
-  return value % node.value[0] === node.value[1];
+  return typeof value === 'number' && value % node.value[0] === node.value[1];
 });
 
 export const size: Interpret<Field<number>, AnyObject | unknown[]> = (node, object, { get }) => {
@@ -88,9 +88,9 @@ export const size: Interpret<Field<number>, AnyObject | unknown[]> = (node, obje
     : test(items);
 };
 
-export const regex = testValueOrArray<RegExp, string>(
-  (node, value) => value !== undefined && node.value.test(value)
-);
+export const regex = testValueOrArray<RegExp, string>((node, value) => {
+  return typeof value === 'string' && node.value.test(value);
+});
 
 export const within = testValueOrArray<unknown[], unknown>((node, object, { equal }) => {
   return includes(node.value, object, equal);

--- a/packages/js/src/interpreters.ts
+++ b/packages/js/src/interpreters.ts
@@ -88,7 +88,9 @@ export const size: Interpret<Field<number>, AnyObject | unknown[]> = (node, obje
     : test(items);
 };
 
-export const regex = testValueOrArray<RegExp, string>((node, value) => node.value.test(value));
+export const regex = testValueOrArray<RegExp, string>(
+  (node, value) => value !== undefined && node.value.test(value)
+);
 
 export const within = testValueOrArray<unknown[], unknown>((node, object, { equal }) => {
   return includes(node.value, object, equal);


### PR DESCRIPTION
prevent regex() from returning true when value is undefined

if key is not defined or if value is undefined, the regex should not evaluate it because it can lead
to false positive.
The undefined type is evaluated as a string 'undefined',\i undefined should be
evaluated with the "exist" operator

