### PR TITLE
fix(objection): table name 'xxx' specified more than once

### DIFF
--- a/packages/sql/src/lib/objection.ts
+++ b/packages/sql/src/lib/objection.ts
@@ -13,6 +13,14 @@ function joinRelation(relationName: string, query: QueryBuilder<Model>) {
     return false;
   }
 
+  // Check if relation has already been joined e.g. with 'withGraphJoined'
+  if (query.hasWithGraph()) {
+    const graphExpression = query.graphExpressionObject();
+    if (graphExpression.$childNames.indexOf(relationName) !== -1) {
+      return true;
+    }
+  }
+
   query.joinRelated(relationName);
   return true;
 }


### PR DESCRIPTION
When a relation was already joined with `withGraphJoined`, ucast was adding the relation
a second time. Now a check for the relation is performed.

fixes #17