### PR TITLE
fix(sql): Interpreters should add one join per relation at most

### DIFF
--- a/packages/sql/spec/sequelize.spec.ts
+++ b/packages/sql/spec/sequelize.spec.ts
@@ -1,4 +1,4 @@
-import { FieldCondition } from '@ucast/core'
+import { FieldCondition, CompoundCondition } from '@ucast/core'
 import { Model, Sequelize, DataTypes } from 'sequelize'
 import { interpret } from '../src/lib/sequelize'
 import { expect } from './specHelper'
@@ -30,6 +30,19 @@ describe('Condition interpreter for Sequelize', () => {
       { association: 'projects', required: true }
     ])
     expect(query.where.val).to.equal('`projects`.`name` = \'test\'')
+  })
+
+  it('should join the same relation exactly one time', () => {
+    const condition = new CompoundCondition('and', [
+      new FieldCondition('eq', 'projects.name', 'test'),
+      new FieldCondition('eq', 'projects.active', true),
+    ])
+
+    const query = interpret(condition, User)
+    expect(query.include).to.deep.equal([
+      { association: 'projects', required: true }
+    ])
+    expect(query.where.val).to.equal('(`projects`.`name` = \'test\' and `projects`.`active` = 1)')
   })
 })
 

--- a/packages/sql/src/lib/typeorm.ts
+++ b/packages/sql/src/lib/typeorm.ts
@@ -9,10 +9,9 @@ import {
 
 function joinRelation<Entity>(relationName: string, query: SelectQueryBuilder<Entity>) {
   const meta = query.expressionMap.mainAlias!.metadata;
+  const joinAlreadyExists = query.expressionMap.joinAttributes
+    .some(j => j.alias.name === relationName);
 
-  const joinAlreadyExists = query.expressionMap.joinAttributes.find((j) => {
-    return j.alias.name === relationName;
-  });
   if (joinAlreadyExists) {
     return true;
   }

--- a/packages/sql/src/lib/typeorm.ts
+++ b/packages/sql/src/lib/typeorm.ts
@@ -9,8 +9,15 @@ import {
 
 function joinRelation<Entity>(relationName: string, query: SelectQueryBuilder<Entity>) {
   const meta = query.expressionMap.mainAlias!.metadata;
-  const relation = meta.findRelationWithPropertyPath(relationName);
 
+  const joinAlreadyExists = query.expressionMap.joinAttributes.find((j) => {
+    return j.alias.name === relationName;
+  });
+  if (joinAlreadyExists) {
+    return true;
+  }
+
+  const relation = meta.findRelationWithPropertyPath(relationName);
   if (relation) {
     query.innerJoin(`${query.alias}.${relationName}`, relationName);
     return true;


### PR DESCRIPTION
If a condition specifies the same relation several times the interpreters should add the join statement only once.

Before this patch:
- `typeorm` add a join statement for each condition that refers to the same relation.
- `sequelize` doesn't include any relation because `joins` var was emptied during `merge` operation.