### PR TITLE
remove type commonjs from package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,6 @@
   "name": "@ucast/core",
   "version": "1.10.0",
   "description": "git@github.com:stalniy/ucast.git",
-  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/es6c/index.js",
   "module": "dist/es5m/index.js",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -2,7 +2,6 @@
   "name": "@ucast/js",
   "version": "3.0.1",
   "description": "git@github.com:stalniy/ucast.git",
-  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/es6c/index.js",
   "module": "dist/es5m/index.js",

--- a/packages/mongo/package.json
+++ b/packages/mongo/package.json
@@ -2,7 +2,6 @@
   "name": "@ucast/mongo",
   "version": "2.4.1",
   "description": "git@github.com:stalniy/ucast.git",
-  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/es6c/index.js",
   "module": "dist/es5m/index.js",

--- a/packages/mongo2js/package.json
+++ b/packages/mongo2js/package.json
@@ -2,7 +2,6 @@
   "name": "@ucast/mongo2js",
   "version": "1.3.2",
   "description": "git@github.com:stalniy/ucast.git",
-  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/es6c/index.js",
   "module": "dist/es5m/index.js",


### PR DESCRIPTION
**What-**

This change removes the type:"commonjs" from all packages. 

**Why -** 

Setting "type" field in package.json forces Webpack to treat all files in the package as either CommonJS or EcmaScript.
Without it Webpack correctly uses "main" and "module" fields.

Fixes https://github.com/stalniy/ucast/issues/27