### PR TITLE
docs(README): fix code sample and describe forPrimitives

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
   npx pnpm add -g pnpm
   cd ucast
   pnpm recursive i
-  pnpm build -r
+  pnpm -r build
   ```
 
 * Make your changes in a new git branch (fork master branch):


### PR DESCRIPTION
While resolving a different issue, I didn't immediately understand the `forPrimitives` option, and it wasn't documented anywhere, so I figured it out by looking at the one place where it's used, and looking up the documentation for `squire` and noticed a glaring issue on the README - in the readme, `createFilter` is used, but no such function exists, and `createFactory` is the correct function.

<details>
<summary>Other notes</summary>

I also would have for custom operators to have better typing, like the following snippet:

```ts
type JSONSchemaQuery<T> = BuildMongoQuery<T, { toplevel: { $jsonSchema: import('json-schema').JSONSchema4 }}>
type JSONSchemaFilter = <
  T = Record<string, unknown>,
  Q extends JSONSchemaQuery<T> = JSONSchemaQuery<T>
>(query: Q) => ThingFilter<T>
const customGuard = createFactory({
  $jsonSchema,
}, {
  jsonSchema
}) as JSONSchemaFilter;
```

</details>