### PR TITLE
feat: ensures that `toJSON` is not called on primitives

### DIFF
--- a/packages/mongo2js/src/factory.ts
+++ b/packages/mongo2js/src/factory.ts
@@ -24,6 +24,10 @@ interface HasToJSON {
 }
 
 function toPrimitive(value: unknown) {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
   if (value instanceof Date) {
     return value.getTime();
   }


### PR DESCRIPTION
This is kind of breaking change that should not affect anybody in 99.9% of cases. Very unlikely that somebody overwrites toJSON on primitives to change the behavior of guard function

https://github.com/stalniy/casl/issues/1016