### PR TITLE
feat: support deeply nested field path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Logs
+.idea
 logs
 *.log
 npm-debug.log*

--- a/packages/sql/spec/interpreters.spec.ts
+++ b/packages/sql/spec/interpreters.spec.ts
@@ -59,6 +59,33 @@ describe('Condition Interpreter', () => {
     })
   })
 
+  describe('auto join nested relations', () => {
+    const interpret = createSqlInterpreter({ eq })
+    const condition = new Field('eq', 'projects.user.name', 'test')
+
+    before(() => {
+      spy.on(options, 'joinRelation')
+    })
+
+    after(() => {
+      spy.restore(options, 'joinRelation')
+    })
+
+    it('calls `joinRelation` function passing relation name when using dot notation', () => {
+      interpret(condition, options)
+      expect(options.joinRelation).to.have.been.called.with('user')
+    })
+
+    it('escapes relation name with `options.escapeField`', () => {
+      spy.on(options, 'escapeField')
+      const [sql] = interpret(condition, options)
+
+      expect(sql).to.equal('"user"."name" = $1')
+      expect(options.escapeField).to.have.been.called.with('user')
+      spy.restore(options, 'escapeField')
+    })
+  })
+
   describe('primitive operators', () => {
     const interpret = createSqlInterpreter({ eq, ne, lt, lte, gt, gte, mod })
 

--- a/packages/sql/src/interpreter.ts
+++ b/packages/sql/src/interpreter.ts
@@ -47,16 +47,14 @@ export class Query {
 
   field(rawName: string) {
     const name = this._fieldPrefix + rawName;
+    let separator = name.lastIndexOf('.');
 
-    const parts = name.split('.')
-      .reverse();
-
-    if (parts.length <= 1 || !this.options.joinRelation) {
-      return this._rootAlias + this.options.escapeField(name);
+    if (separator === -1 || !this.options.joinRelation) {
+      return this._rootAlias + this._localField(name);
     }
 
-    const field = parts.shift() as string;
-    const relationName = parts.shift() as string;
+    const field = name.slice(separator + 1);
+    const relationName = name.slice(0, separator);
 
     if (!this.options.joinRelation(relationName, this._relationContext)) {
       return this._rootAlias + this._localField(name);

--- a/packages/sql/src/interpreter.ts
+++ b/packages/sql/src/interpreter.ts
@@ -48,18 +48,15 @@ export class Query {
   field(rawName: string) {
     const name = this._fieldPrefix + rawName;
 
-    if (!this.options.joinRelation) {
-      return this._rootAlias + this._localField(name);
+    const parts = name.split('.')
+      .reverse();
+
+    if (parts.length <= 1 || !this.options.joinRelation) {
+      return this._rootAlias + this.options.escapeField(name);
     }
 
-    const relationNameIndex = name.indexOf('.');
-
-    if (relationNameIndex === -1) {
-      return this._rootAlias + this._localField(name);
-    }
-
-    const relationName = name.slice(0, relationNameIndex);
-    const field = name.slice(relationNameIndex + 1);
+    const field = parts.shift() as string;
+    const relationName = parts.shift() as string;
 
     if (!this.options.joinRelation(relationName, this._relationContext)) {
       return this._rootAlias + this._localField(name);

--- a/packages/sql/src/lib/mikro-orm.ts
+++ b/packages/sql/src/lib/mikro-orm.ts
@@ -7,18 +7,35 @@ import {
   mysql,
   type SqlOperator
 } from '../index';
+import { splitRelationName } from './utils';
 
-function joinRelation(relationName: string, query: QueryBuilder) {
+function joinRelation(relationPath: string, query: QueryBuilder) {
+  let relationFullName = relationPath;
   const privateQuery = query as any;
-  const meta = privateQuery.mainAlias.metadata as EntityMetadata;
-  const prop = meta.properties[relationName];
+  let meta = privateQuery.mainAlias.metadata as EntityMetadata;
+  let alias = query.alias;
 
-  if (prop?.ref) {
-    query.join(`${query.alias}.${relationName}`, relationName);
-    return true;
+  while (relationFullName) {
+    let relationName: string;
+    [relationName, relationFullName] = splitRelationName(relationFullName);
+
+    const relation = meta.properties[relationName];
+
+    if (relation?.ref) {
+      query.join(`${alias}.${relationName}`, relationName);
+
+      if (!relation.targetMeta) {
+        return false;
+      }
+
+      meta = relation.targetMeta;
+      alias = relationName;
+    } else {
+      return false;
+    }
   }
 
-  return false;
+  return true;
 }
 
 const dialects = createDialects({

--- a/packages/sql/src/lib/objection.ts
+++ b/packages/sql/src/lib/objection.ts
@@ -7,13 +7,26 @@ import {
   createDialects,
   mysql,
 } from '../index';
+import { splitRelationName } from './utils';
 
-function joinRelation(relationName: string, query: QueryBuilder<Model>) {
-  if (!query.modelClass().getRelation(relationName)) {
-    return false;
+function joinRelation(input: string, query: QueryBuilder<Model>) {
+  let relationFullName : string | undefined = input;
+  let modelClass = query.modelClass();
+
+  while (relationFullName) {
+    let relationName : string;
+    [relationName, relationFullName] = splitRelationName(relationFullName);
+
+    const relation = modelClass.getRelation(relationName);
+    if (relation) {
+      query.joinRelated(relationName);
+
+      modelClass = relation.joinModelClass;
+    } else {
+      return false;
+    }
   }
 
-  query.joinRelated(relationName);
   return true;
 }
 

--- a/packages/sql/src/lib/sequelize.ts
+++ b/packages/sql/src/lib/sequelize.ts
@@ -7,12 +7,21 @@ import {
   createDialects,
   mysql
 } from '../index';
+import { splitRelationName, hasOwn } from './utils';
 
-const hasOwn = Object.hasOwn ||
-  Object.prototype.hasOwnProperty.call.bind(Object.prototype.hasOwnProperty);
+function joinRelation(relationPath: string, Model: ModelStatic<any>) {
+  let relationFullName = relationPath;
 
-function joinRelation(relationName: string, Model: ModelStatic<any>) {
-  return hasOwn(Model.associations, relationName);
+  while (relationFullName) {
+    let relationName: string;
+    [relationName, relationFullName] = splitRelationName(relationFullName);
+
+    if (!hasOwn(Model.associations, relationName)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 const dialects = createDialects({

--- a/packages/sql/src/lib/typeorm.ts
+++ b/packages/sql/src/lib/typeorm.ts
@@ -6,26 +6,21 @@ import {
   type SqlOperator,
   createDialects
 } from '../index';
+import { splitRelationName } from './utils';
 
 function joinRelation<Entity extends ObjectLiteral>(relationPath: string, query: SelectQueryBuilder<Entity>) {
   let relationFullName = relationPath;
   let meta = query.expressionMap.mainAlias!.metadata;
-  let alias : string | undefined = query.alias;
+  let alias = query.alias;
 
-  while (relationFullName.length) {
-    const separatorIndex = relationFullName.indexOf('.');
-
-    let relationName : string;
-    if (separatorIndex === -1) {
-      relationName = relationFullName;
-      relationFullName = '';
-    } else {
-      relationName = relationFullName.slice(0, separatorIndex);
-      relationFullName = relationFullName.slice(separatorIndex + 1);
-    }
+  while (relationFullName) {
+    let relationName: string;
+    [relationName, relationFullName] = splitRelationName(relationFullName);
 
     const relation = meta.findRelationWithPropertyPath(relationName);
     if (relation) {
+      // BUGALERT: query is modified but if some relation doesn't exist, and joinRelation returns false,
+      // then query will join relations which are not needed
       query.innerJoin(`${alias}.${relationName}`, relationName);
 
       meta = relation.entityMetadata;

--- a/packages/sql/src/lib/typeorm.ts
+++ b/packages/sql/src/lib/typeorm.ts
@@ -7,25 +7,35 @@ import {
   createDialects
 } from '../index';
 
-function joinRelation<Entity extends ObjectLiteral>(
-  relationName: string,
-  query: SelectQueryBuilder<Entity>,
-) {
-  const meta = query.expressionMap.mainAlias!.metadata;
-  const joinAlreadyExists = query.expressionMap.joinAttributes
-    .some(j => j.alias.name === relationName);
+function joinRelation<Entity extends ObjectLiteral>(relationPath: string, query: SelectQueryBuilder<Entity>) {
+  let relationFullName = relationPath;
+  let meta = query.expressionMap.mainAlias!.metadata;
+  let alias : string | undefined = query.alias;
 
-  if (joinAlreadyExists) {
-    return true;
+  while (relationFullName.length) {
+    const separatorIndex = relationFullName.indexOf('.');
+
+    let relationName : string;
+    if (separatorIndex === -1) {
+      relationName = relationFullName;
+      relationFullName = '';
+    } else {
+      relationName = relationFullName.slice(0, separatorIndex);
+      relationFullName = relationFullName.slice(separatorIndex + 1);
+    }
+
+    const relation = meta.findRelationWithPropertyPath(relationName);
+    if (relation) {
+      query.innerJoin(`${alias}.${relationName}`, relationName);
+
+      meta = relation.entityMetadata;
+      alias = relationName;
+    } else {
+      return false;
+    }
   }
 
-  const relation = meta.findRelationWithPropertyPath(relationName);
-  if (relation) {
-    query.innerJoin(`${query.alias}.${relationName}`, relationName);
-    return true;
-  }
-
-  return false;
+  return true;
 }
 
 const dialects = createDialects({

--- a/packages/sql/src/lib/utils.ts
+++ b/packages/sql/src/lib/utils.ts
@@ -1,0 +1,15 @@
+export function splitRelationName(input: string) : [string, string] {
+  const separatorIndex = input.indexOf('.');
+
+  if (separatorIndex === -1) {
+    return [input, ''];
+  }
+
+  return [
+    input.slice(0, separatorIndex),
+    input.slice(separatorIndex + 1),
+  ];
+}
+
+export const hasOwn = Object.hasOwn ||
+  Object.prototype.hasOwnProperty.call.bind(Object.prototype.hasOwnProperty);


### PR DESCRIPTION
# Behaviour
## Previous

```ts
const field = new Field('eq', 'projects.user.name', 'test');
const [sql] = interpret(condition, /* ... */)
// "projects"."user.name" = $1
```

## New

```ts
const field = new Field('eq', 'projects.user.name', 'test');
const [sql] = interpret(condition, /* ... */)
// "user"."name" = $1
```

# Todo
- adjust joinRelation function to accept path as relation-name ( split name and auto include parents)