### PR TITLE
refactor: makes optimizeCompoundCondition to walk only 1 level deep

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -1,4 +1,5 @@
 name: 'Setup dependencies'
+description: 'Install Node.js, pnpm, and cached project dependencies'
 
 inputs:
   node-version:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,8 +34,10 @@ jobs:
         pnpm run -r lint
         pnpm run -r coverage
     - name: Submit coverage
-      uses: codecov/codecov-action@v5
+      if: matrix.node == 'latest'
+      uses: codecov/codecov-action@v6
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
+        version: v11.2.8
         verbose: true # optional (default = false)

--- a/packages/core/spec/optimizedCompoundCondition.spec.ts
+++ b/packages/core/spec/optimizedCompoundCondition.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { optimizedCompoundCondition, FieldCondition, CompoundCondition } from '../src'
+import { optimizedCompoundCondition, FieldCondition, CompoundCondition, buildAnd, buildOr } from '../src'
 
 describe('optimizedCompoundCondition', () => {
   const child = new FieldCondition('eq', 'x', 1)
@@ -9,30 +9,65 @@ describe('optimizedCompoundCondition', () => {
     expect(ast).to.equal(child)
   })
 
-  it('merges children conditions with the same name recursively', () => {
-    const ast = optimizedCompoundCondition('and', [
-      new CompoundCondition('and', [
-        new CompoundCondition('and', [child]),
-        child
-      ]),
-      child
-    ])
-
-    expect(ast).to.deep.equal(new CompoundCondition('and', [child, child, child]))
+  it('reuses conditions array if there is nothing to flatten', () => {
+    const conditions = [child, child]
+    const ast = optimizedCompoundCondition('and', conditions) as CompoundCondition
+    expect(ast.value).to.equal(conditions)
   })
 
-  it('does not merge compound conditions with another operator name', () => {
+  it('merges direct children conditions with the same name', () => {
     const ast = optimizedCompoundCondition('and', [
-      new CompoundCondition('and', [
-        new CompoundCondition('or', [child]),
+      optimizedCompoundCondition('and', [
+        optimizedCompoundCondition('and', [child]),
         child
       ]),
       child
     ])
 
     expect(ast).to.deep.equal(new CompoundCondition('and', [
-      new CompoundCondition('or', [child]),
       child,
+      child,
+      child
+    ]))
+  })
+
+  it('does not merge compound conditions with another operator name', () => {
+    const ast = optimizedCompoundCondition('and', [
+      optimizedCompoundCondition('and', [
+        optimizedCompoundCondition('or', [child]),
+        child
+      ]),
+      child
+    ])
+
+    expect(ast).to.deep.equal(new CompoundCondition('and', [
+      child,
+      child,
+      child
+    ]))
+  })
+
+  it('removes empty compound identity conditions', () => {
+    expect(buildAnd([new CompoundCondition('and', []), child])).to.equal(child)
+    expect(buildOr([new CompoundCondition('or', []), child])).to.equal(child)
+  })
+
+  it('preserves empty compound conditions with another operator name', () => {
+    expect(buildAnd([
+      buildOr([buildOr([])]),
+      buildOr([]),
+      child
+    ])).to.deep.equal(new CompoundCondition('and', [
+      new CompoundCondition('or', []),
+      new CompoundCondition('or', []),
+      child
+    ]))
+
+    expect(buildOr([
+      buildAnd([buildAnd([])]),
+      child
+    ])).to.deep.equal(new CompoundCondition('or', [
+      new CompoundCondition('and', []),
       child
     ]))
   })

--- a/packages/core/src/translator.ts
+++ b/packages/core/src/translator.ts
@@ -3,7 +3,7 @@ import { Parse } from './types';
 import { AnyInterpreter } from './interpreter';
 
 type Bound<T> = T extends (first: Condition, ...args: infer A) => any
-  ? { (...args: A): ReturnType<T>, ast: Condition }
+  ? { (...args: A): ReturnType<T>, ast: Condition; }
   : never;
 
 export function createTranslatorFactory<Lang, Interpreter extends AnyInterpreter>(
@@ -13,7 +13,9 @@ export function createTranslatorFactory<Lang, Interpreter extends AnyInterpreter
   return (query: Lang, ...args: unknown[]): Bound<Interpreter> => {
     const ast = parse(query, ...args);
     const translate = (interpret as any).bind(null, ast);
-    translate.ast = ast;
+    Object.defineProperty(translate, 'ast', {
+      value: ast
+    });
     return translate;
   };
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -9,22 +9,33 @@ export function isCompound(operator: string, condition: Condition): condition is
 
 function flattenConditions<T extends Condition>(
   operator: string,
-  conditions: T[],
-  aggregatedResult?: T[]
+  conditions: T[]
 ) {
-  const flatConditions: T[] = aggregatedResult || [];
+  let flatConditions: T[] | undefined;
 
   for (let i = 0, length = conditions.length; i < length; i++) {
     const currentNode = conditions[i];
 
-    if (isCompound(operator, currentNode)) {
-      flattenConditions(operator, currentNode.value as T[], flatConditions);
-    } else {
+    if (currentNode instanceof CompoundCondition) {
+      if (currentNode.operator !== operator) {
+        if (flatConditions) flatConditions.push(currentNode);
+        continue;
+      }
+
+      if (!flatConditions) {
+        flatConditions = conditions.slice(0, i);
+      }
+
+      const nestedConditions = currentNode.value as T[];
+      for (let j = 0, nestedLength = nestedConditions.length; j < nestedLength; j++) {
+        flatConditions.push(nestedConditions[j]);
+      }
+    } else if (flatConditions) {
       flatConditions.push(currentNode);
     }
   }
 
-  return flatConditions;
+  return flatConditions || conditions;
 }
 
 export function optimizedCompoundCondition<T extends Condition>(operator: string, conditions: T[]) {
@@ -32,7 +43,10 @@ export function optimizedCompoundCondition<T extends Condition>(operator: string
     return conditions[0];
   }
 
-  return new CompoundCondition(operator, flattenConditions(operator, conditions));
+  const optimized = flattenConditions(operator, conditions);
+  return optimized.length === 1
+    ? optimized[0]
+    : new CompoundCondition(operator, optimized);
 }
 
 export const identity = <T>(x: T) => x;
@@ -54,7 +68,7 @@ export function hasOperators<T>(
     return false;
   }
 
-  for (const prop in value) {  
+  for (const prop in value) {
     const hasProp = hasOwn(value, prop) && hasOwn(instructions, prop);
     if (hasProp && (!skipIgnore || value[prop] !== ignoreValue)) {
       return true;
@@ -66,7 +80,7 @@ export function hasOperators<T>(
 
 export function objectKeysSkipIgnore(anyObject: Record<string, unknown>) {
   const keys: string[] = [];
-  for (const key in anyObject) {  
+  for (const key in anyObject) {
     if (hasOwn(anyObject, key) && anyObject[key] !== ignoreValue) {
       keys.push(key);
     }


### PR DESCRIPTION
## Why

No need to go recursively over already optimized conditions

## What

1. makes optimizeCompoundCondition to walk only 1 level deep
2. makes array allocation lazily to reduce pressure on GC