### PR TITLE
refactor: preserves empty AND and OR conditions during condition optimization

### DIFF
--- a/packages/core/spec/optimizedCompoundCondition.spec.ts
+++ b/packages/core/spec/optimizedCompoundCondition.spec.ts
@@ -47,9 +47,9 @@ describe('optimizedCompoundCondition', () => {
     ]))
   })
 
-  it('removes empty compound identity conditions', () => {
-    expect(buildAnd([new CompoundCondition('and', []), child])).to.equal(child)
-    expect(buildOr([new CompoundCondition('or', []), child])).to.equal(child)
+  it('preserves empty empty compound identity conditions', () => {
+    expect(buildAnd([new CompoundCondition('and', []), child])).to.deep.equal(buildAnd([new CompoundCondition('and', []), child]))
+    expect(buildOr([new CompoundCondition('or', []), child])).to.deep.equal(buildOr([new CompoundCondition('or', []), child]))
   })
 
   it('preserves empty compound conditions with another operator name', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -23,6 +23,10 @@ function flattenConditions<T extends Condition>(
         continue;
       }
 
+      if (currentNode.value.length === 0) {
+        continue;
+      }
+
       if (!flatConditions) {
         flatConditions = conditions.slice(0, i);
       }
@@ -40,14 +44,13 @@ function flattenConditions<T extends Condition>(
 }
 
 export function optimizedCompoundCondition<T extends Condition>(operator: string, conditions: T[]) {
-  if (conditions.length === 1) {
-    return conditions[0];
-  }
+  if (conditions.length === 1) return conditions[0];
+  if (conditions.length === 0) return new CompoundCondition(operator, conditions);
 
   const optimized = flattenConditions(operator, conditions);
-  return optimized.length === 1
-    ? optimized[0]
-    : new CompoundCondition(operator, optimized);
+  if (optimized.length === 1) return optimized[0];
+  if (optimized.length === 0) return new CompoundCondition(operator, optimized);
+  return new CompoundCondition(operator, optimized);
 }
 
 export const identity = <T>(x: T) => x;


### PR DESCRIPTION
**BREAKING CHANGE**: previously empty AND and OR conditions were removed as an optimization. But this breaks rule semantic and potential postprocessing to catch user errors.