### PR TITLE
feat: add strictOperators option to ObjectQueryParser

### DIFF
--- a/packages/core/spec/ObjectQueryParser.spec.ts
+++ b/packages/core/spec/ObjectQueryParser.spec.ts
@@ -179,6 +179,68 @@ describe('ObjectQueryParser', () => {
     })
   })
 
+  describe('when "strictOperators" is enabled', () => {
+    it('throws when field value is an object whose keys are not registered operators', () => {
+      const parser = new ObjectQueryParser({ eq }, { strictOperators: true })
+
+      expect(() => parser.parse({ status: { equals: 'published' } }))
+        .to.throw(/Unrecognized operator key\(s\) in field query for "status": equals/)
+    })
+
+    it('lists every unrecognized key in the error message', () => {
+      const parser = new ObjectQueryParser({ eq }, { strictOperators: true })
+
+      expect(() => parser.parse({ status: { equals: 'x', value: 'y' } }))
+        .to.throw(/equals, value/)
+    })
+
+    it('does not throw when field value is a primitive (field-name shorthand)', () => {
+      const parser = new ObjectQueryParser({ eq }, { strictOperators: true })
+
+      expect(() => parser.parse({ status: 'published' })).to.not.throw()
+    })
+
+    it('does not throw when field value is null', () => {
+      const parser = new ObjectQueryParser({ eq }, { strictOperators: true })
+
+      expect(() => parser.parse({ status: null })).to.not.throw()
+    })
+
+    it('does not throw when field value is an array', () => {
+      const parser = new ObjectQueryParser({ eq }, { strictOperators: true })
+
+      expect(() => parser.parse({ status: ['published', 'draft'] })).to.not.throw()
+    })
+
+    it('does not throw when field value is a Date or other non-plain object', () => {
+      const parser = new ObjectQueryParser({ eq }, { strictOperators: true })
+
+      expect(() => parser.parse({ createdAt: new Date() })).to.not.throw()
+    })
+
+    it('does not throw when the value contains a registered operator', () => {
+      const parser = new ObjectQueryParser({ eq }, { strictOperators: true })
+
+      expect(() => parser.parse({ status: { eq: 'published' } })).to.not.throw()
+    })
+
+    it('does not throw for an empty object value', () => {
+      // {} is unambiguous — it deep-equals only the literal empty object;
+      // strict mode should not break that legitimate (if unusual) case.
+      const parser = new ObjectQueryParser({ eq }, { strictOperators: true })
+
+      expect(() => parser.parse({ status: {} })).to.not.throw()
+    })
+
+    it('does not change behavior when disabled (default)', () => {
+      const parser = new ObjectQueryParser({ eq })
+
+      // Without the flag, the wrong-shape rule compiles silently as
+      // `status eq { equals: 'published' }` — documented current behaviour.
+      expect(() => parser.parse({ status: { equals: 'published' } })).to.not.throw()
+    })
+  })
+
   describe('when "useIgnoreValue" is enabled', () => {
     describe('field level operators', () => {
       it('ignores properties that equals to `ignoreValue`', () => {

--- a/packages/core/src/parsers/ObjectQueryParser.ts
+++ b/packages/core/src/parsers/ObjectQueryParser.ts
@@ -28,6 +28,26 @@ export interface QueryOptions {
   documentContext?: Record<string, unknown>
   useIgnoreValue?: boolean
   mergeFinalConditions?(conditions: Condition[]): Condition
+  /**
+   * When `true`, the parser throws on field values that are plain objects
+   * whose keys do NOT include any registered operator, instead of silently
+   * falling back to treating the parent key as a field name with the
+   * default operator.
+   *
+   * Without this flag, `{ status: { equals: 'x' } }` against a parser where
+   * `equals` is not registered (e.g. Mongo, whose canonical operator is
+   * `$eq`) compiles as `status defaultOp { equals: 'x' }` and never matches
+   * at runtime. The fallback is convenient for legitimate field-name
+   * shorthand (`{ name: 'alice' }`) but masks wrong-shape rules from
+   * hand-rolled translators and dialect mix-ups.
+   *
+   * Field-name shorthand for primitive, array, and non-plain-object values
+   * (e.g. Date) continues to work. Only the "object value with all-unknown
+   * keys" shape is rejected.
+   *
+   * Defaults to `false` for backwards compatibility.
+   */
+  strictOperators?: boolean
 }
 
 export type ObjectQueryFieldParsingContext = ParsingContext<FieldParsingContext & {
@@ -42,9 +62,10 @@ export class ObjectQueryParser<
   private readonly _instructions: ParsingInstructions;
   private _fieldInstructionContext: ObjectQueryFieldParsingContext;
   private _documentInstructionContext: ParsingContext<{ query: {} }>;
-  private readonly _options: Required<
-  Pick<QueryOptions, 'operatorToConditionName' | 'defaultOperatorName' | 'mergeFinalConditions'>
-  >;
+  private readonly _options: Required<Pick<
+  QueryOptions,
+  'operatorToConditionName' | 'defaultOperatorName' | 'mergeFinalConditions' | 'strictOperators'
+  >>;
 
   private readonly _objectKeys: typeof Object.keys;
 
@@ -54,6 +75,7 @@ export class ObjectQueryParser<
       operatorToConditionName: options.operatorToConditionName || identity,
       defaultOperatorName: options.defaultOperatorName || 'eq',
       mergeFinalConditions: options.mergeFinalConditions || buildAnd,
+      strictOperators: options.strictOperators === true,
     };
     this._instructions = Object.keys(instructions).reduce((all, name) => {
       all[name] = { name: this._options.operatorToConditionName(name), ...instructions[name] };
@@ -115,6 +137,22 @@ export class ObjectQueryParser<
     return parse(instruction, value, context);
   }
 
+  protected assertNoUnknownOperatorObject(field: string, value: unknown): void {
+    if (!value || (value as { constructor?: unknown }).constructor !== Object) {
+      return;
+    }
+
+    const keys = this._objectKeys(value as Record<string, unknown>);
+
+    if (keys.length === 0) {
+      return;
+    }
+
+    throw new Error(
+      `Unrecognized operator key(s) in field query for "${field}": ${keys.join(', ')}`
+    );
+  }
+
   protected parseFieldOperators(field: string, value: U) {
     const conditions: Condition[] = [];
     const keys = this._objectKeys(value);
@@ -157,6 +195,9 @@ export class ObjectQueryParser<
       } else if (this._fieldInstructionContext.hasOperators<U>(value)) {
         conditions.push(...this.parseFieldOperators(key, value));
       } else {
+        if (this._options.strictOperators) {
+          this.assertNoUnknownOperatorObject(key, value);
+        }
         pushIfNonNullCondition(
           conditions,
           this.parseField(key, this._options.defaultOperatorName, value, query)


### PR DESCRIPTION
## Summary

Adds an opt-in `strictOperators?: boolean` flag to `ObjectQueryParser`'s `QueryOptions`. When enabled, the parser throws at parse time on field values that are plain objects whose keys are NOT registered operators, instead of silently falling back to treating the parent key as a field name with the default operator.

## Motivation

`ObjectQueryParser` currently has three branches when walking a top-level key in a query:

1. The key is a registered top-level operator (e.g. `$or`, `$and`) → parse as operator.
2. The value contains at least one registered operator → parse as `parseFieldOperators`.
3. Neither → fall back to `parseField(key, defaultOperatorName, value, query)` — i.e., treat the parent key as a field name and the value as the RHS of the default operator.

Branch 3 is useful for legitimate field-name shorthand:

```ts
parser.parse({ name: 'alice' })
// => FieldCondition('eq', 'name', 'alice')   ✅ intended
```

But it also silently accepts wrong-shape rules from hand-rolled translators and dialect mix-ups:

```ts
// Mongo-style parser; canonical equality operator is `$eq`.
// The translator emitted Prisma-style `equals` by mistake.
parser.parse({ status: { equals: 'published' } })
// => FieldCondition('eq', 'status', { equals: 'published' })   ❌ silent
//                                  └─ object as the RHS of $eq; never matches at runtime
```

For consumers of `@ucast/core` that build SQL / Drizzle / TypeORM `accessibleBy()`-style adapters on top of the AST, the failure can be worse: adapters often drop unrecognized keys when assembling a WHERE clause, leaving the rule's conditions as "no filter" and returning every row. That's a silent permission escalation in authorization-library contexts.

A runnable 7-case repro against `@casl/ability` + `@casl/prisma`:
https://github.com/luzan/nest-warden/tree/main/examples/casl-conditions-demo

## What changed

- New `QueryOptions.strictOperators?: boolean` (defaults to `false`).
- New `protected assertNoUnknownOperatorObject(field, value)` helper that throws `Unrecognized operator key(s) in field query for "<field>": <keys>` when `value` is a non-empty plain object.
- The fallback branch in `parse()` calls the assertion before `parseField` when strict mode is on.

Field-name shorthand for primitive, array, `null`, and non-plain-object values (Date, etc.) continues to work. Only the **object value with all-unknown keys** shape is rejected. Empty objects (`{}`) are accepted as well since they're unambiguous (`field eq {}` deep-equals the literal empty object — unusual but valid).

## Tests

9 new specs added under `describe('when "strictOperators" is enabled', ...)` in `packages/core/spec/ObjectQueryParser.spec.ts`:

- Throws on `{ field: { unknownOp: 'x' } }`.
- Lists every unrecognized key in the error message.
- Does NOT throw on primitive / array / null / Date values.
- Does NOT throw when the value contains a registered operator.
- Does NOT throw on empty `{}`.
- Does NOT change behavior when disabled (default).

Full suite: `pnpm test` in `packages/core` → 47 passing (was 38). `pnpm -r test` across the monorepo also green; no downstream packages affected.

## Backwards compatibility

100% backwards compatible. The flag defaults to `false`, and when it's off the parse loop is byte-for-byte identical to before (no extra branch, no extra allocation in the hot path).

## Why ship this in `@ucast/core` and not just in a derived parser

Every parser that extends `ObjectQueryParser` — Mongo, Prisma, the future ones — inherits the silent-fallback behavior. Putting the strict flag at the base class means a single opt-in turns it on across every dialect, which is the right ergonomics for consumers who want to catch translator bugs at boot time across their whole authorization layer.