### PR TITLE
feat(sql)!: resolve relations through EXISTS metadata

### DIFF
--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -3,7 +3,7 @@
 [![@ucast/sql NPM version](https://badge.fury.io/js/%40ucast%2Fsql.svg)](https://badge.fury.io/js/%40ucast%2Fsql)
 [![](https://img.shields.io/npm/dm/%40ucast%2Fsql.svg)](https://www.npmjs.com/package/%40ucast%2Fsql)
 
-This package is a part of [ucast] ecosystem. It provides an interpreter that can translates ucast conditions into [SQL query](https://en.wikipedia.org/wiki/SQL).
+This package is a part of [ucast] ecosystem. It provides an interpreter that can translate ucast conditions into [SQL query](https://en.wikipedia.org/wiki/SQL).
 
 [ucast]: https://github.com/stalniy/ucast
 
@@ -18,8 +18,6 @@ pnpm add @ucast/sql
 ```
 
 ## Getting Started
-
-Latest code is in `alpha` branch and in the latest [npm install @ucast/sql@alpha](https://www.npmjs.com/package/@ucast/sql/v/1.0.0-alpha.12)
 
 ### Interpret conditions AST
 
@@ -42,8 +40,8 @@ const interpret = createSqlInterpreter(allInterpreters);
 `interpret` is a function that takes up to 3 parameters:
 
 1. `Condition`, condition to interpret
-2. `options`, SQL dialect specific options that tells how to escape field, create placeholders and join related tables. `@ucast/sql` provides options for the most popular SQL dialects.
-3. `targetQuery`, optional, this is the parameter that `@ucast/sql` passes as the 2nd one to `joinRelation` function. This is useful when integrating with ORMs and their query builders.
+2. `options`, SQL dialect specific options that tells how to escape field names and create placeholders. `@ucast/sql` provides options for the most popular SQL dialects.
+3. `relationContext`, optional, this value is passed to `getRelationMetadata` and is useful when integrating with ORMs and their metadata.
 
 For the sake of an example, we will create AST manually using `Condition` from `@ucast/core`:
 
@@ -71,30 +69,68 @@ const condition = new CompoundCondition('and', [
 const interpret = createSqlInterpreter(allInterpreters);
 
 const [sql, replacements] = interpret(condition, {
-  ...pg,
-  joinRelation: () => false
+  ...pg
 })
 
-console.log(sql) // ("x" > $1 and "y < $2)
+console.log(sql) // ("x" > $1 and "y" < $2)
 console.log(replacements) // [5, 10]
 ```
 
-### Conditions on related table
+### Conditions on related tables
 
-Interpreter automatically detects fields with dot (`.`) inside and interprets them as fields of a relation. It's possible to automatically inner join table using `options.joinRelation` function. That function accepts 2 parameters: relation name and targetQuery (3rd argument of `interpret` function). For example:
+Use `some`, `none`, and `every` to express conditions against related records:
+
+* `some` checks that at least one related record matches the condition
+* `none` checks that no related records match the condition
+* `every` checks that no related record violates the condition
+
+Relation operators need metadata that describes how the current table is connected to the related table. ORM integrations provide this automatically, so in most cases you can use relation conditions directly:
 
 ```js
-const condition = new FieldCondition('eq', 'address.street', 'some street');
-const relations = { address: '"address"."id" = "address_id"' };
-const [sql, params, joins] = interpret(condition, {
+import { FieldCondition } from '@ucast/core';
+
+const condition = new FieldCondition(
+  'some',
+  'projects',
+  new FieldCondition('eq', 'active', true),
+);
+```
+
+When using `createSqlInterpreter` directly, or when your domain model is not mapped 1-to-1 to database tables, provide `getRelationMetadata`:
+
+```js
+import { FieldCondition } from '@ucast/core';
+import { allInterpreters, createSqlInterpreter, pg } from '@ucast/sql';
+
+const interpret = createSqlInterpreter(allInterpreters);
+const condition = new FieldCondition(
+  'some',
+  'projects',
+  new FieldCondition('eq', 'active', true),
+);
+
+const [sql, params] = interpret(condition, {
   ...pg,
-  joinRelation: relationName => relations.hasOwnProperty(relationName)
+  rootAlias: 'users',
+  getRelationMetadata(relationName) {
+    if (relationName !== 'projects') {
+      return undefined;
+    }
+
+    return {
+      parentField: 'id',
+      relationField: 'user_id',
+      relationTable: 'projects',
+    };
+  },
 });
 
-console.log(sql); // "address"."street" = $1
-console.log(params); // ['some street']
-console.log(joins); // ['address']
+console.log(sql);
+// EXISTS (SELECT 1 FROM "projects" as "projects_0" WHERE "users"."id" = "projects_0"."user_id" AND ("projects_0"."active" = $1))
+console.log(params); // [true]
 ```
+
+For composite keys, many-to-many relations, or permission-specific joins, return custom metadata with `buildRelationQuery`. Use `relationContext` when nested relation conditions need to resolve metadata from the related entity.
 
 ### Custom interpreter
 
@@ -162,7 +198,6 @@ const condition = new CompoundCondition('and', [
 ]);
 
 // {
-//  include: [],
 //  where: literal('(`blocked` = 0 and lastLoggedIn < 1597594415354)')
 // }
 const query = interpret(condition, User)

--- a/packages/sql/mikro-orm/package.json
+++ b/packages/sql/mikro-orm/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "@ucast/sql-mikro-orm",
-  "private": true,
-  "typings": "../dist/types/lib/mikro-orm.d.ts",
-  "main": "../dist/cjs/lib/mikro-orm.js",
-  "es2015": "../dist/esm/lib/mikro-orm.mjs"
-}

--- a/packages/sql/objection/package.json
+++ b/packages/sql/objection/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "@ucast/sql-objection",
-  "private": true,
-  "typings": "../dist/types/lib/objection.d.ts",
-  "main": "../dist/cjs/lib/objection.js",
-  "es2015": "../dist/esm/lib/objection.mjs"
-}

--- a/packages/sql/sequelize/package.json
+++ b/packages/sql/sequelize/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "@ucast/sql-sequelize",
-  "private": true,
-  "typings": "../dist/types/lib/sequelize.d.ts",
-  "main": "../dist/cjs/lib/sequelize.js",
-  "es2015": "../dist/esm/lib/sequelize.mjs"
-}

--- a/packages/sql/spec/interpreters.spec.ts
+++ b/packages/sql/spec/interpreters.spec.ts
@@ -1,5 +1,5 @@
 import { FieldCondition as Field, CompoundCondition } from '@ucast/core'
-import { expect, spy } from './specHelper.ts'
+import { expect } from './specHelper.ts'
 import {
   createSqlInterpreter,
   eq,
@@ -16,49 +16,22 @@ import {
   or,
   nor,
   mod,
-  elemMatch,
   regex,
   pg,
   oracle,
   mysql,
   mssql,
   type SqlQueryOptions,
+  someRelation,
+  noneRelation,
+  everyRelation,
 } from '../src/index.ts'
 
-const joinRelation = () => true
 const options: SqlQueryOptions = {
   ...pg,
-  joinRelation,
 }
 
 describe('Condition Interpreter', () => {
-  describe('auto join', () => {
-    const interpret = createSqlInterpreter({ eq })
-    const condition = new Field('eq', 'projects.name', 'test')
-
-    before(() => {
-      spy.on(options, 'joinRelation')
-    })
-
-    after(() => {
-      spy.restore(options, 'joinRelation')
-    })
-
-    it('calls `joinRelation` function passing relation name when using dot notation', () => {
-      interpret(condition, options)
-      expect(options.joinRelation).to.have.been.called.with('projects')
-    })
-
-    it('escapes relation name with `options.escapeField`', () => {
-      spy.on(options, 'escapeField')
-      const [sql] = interpret(condition, options)
-
-      expect(sql).to.equal('"projects"."name" = $1')
-      expect(options.escapeField).to.have.been.called.with('projects')
-      spy.restore(options, 'escapeField')
-    })
-  })
-
   describe('primitive operators', () => {
     const interpret = createSqlInterpreter({ eq, ne, lt, lte, gt, gte, mod })
 
@@ -250,47 +223,12 @@ describe('Condition Interpreter', () => {
     })
   })
 
-  describe('elemMatch', () => {
-    const interpret = createSqlInterpreter({ elemMatch, eq, or, and, lt, gt })
-
-    it('generates query from a field condition based on relation', () => {
-      const condition = new Field('elemMatch', 'projects', new Field('eq', 'active', true))
-      const [sql, params] = interpret(condition, options)
-
-      expect(sql).to.equal('"projects"."active" = $1')
-      expect(params).to.deep.equal([true])
-    })
-
-    it('generates query from a compound condition based on relation', () => {
-      const condition = new Field('elemMatch', 'projects', new CompoundCondition('and', [
-        new Field('gt', 'count', 5),
-        new Field('lt', 'count', 10),
-      ]))
-      const [sql, params] = interpret(condition, options)
-
-      expect(sql).to.equal('("projects"."count" > $1 and "projects"."count" < $2)')
-      expect(params).to.deep.equal([5, 10])
-    })
-
-    it('calls "joinRelation" option for every field', () => {
-      spy.on(options, 'joinRelation')
-      const condition = new Field('elemMatch', 'projects', new CompoundCondition('and', [
-        new Field('gt', 'count', 5),
-        new Field('lt', 'count', 10),
-      ]))
-      interpret(condition, options)
-
-      expect(options.joinRelation).to.have.been.called.twice
-      spy.restore(options, 'joinRelation')
-    })
-  })
-
   describe('regex', () => {
     const interpret = createSqlInterpreter({ regex })
 
     it('generates posix operator for PostgreSQL', () => {
       const condition = new Field('regex', 'email', /@/)
-      const [sql, params] = interpret(condition, { ...pg, joinRelation })
+      const [sql, params] = interpret(condition, { ...pg })
 
       expect(sql).to.equal('"email" ~ $1')
       expect(params).to.deep.equal([condition.value.source])
@@ -298,7 +236,7 @@ describe('Condition Interpreter', () => {
 
     it('generates posix operator for Oracle', () => {
       const condition = new Field('regex', 'email', /@/)
-      const [sql, params] = interpret(condition, { ...oracle, joinRelation })
+      const [sql, params] = interpret(condition, { ...oracle })
 
       expect(sql).to.equal('"email" ~ $1')
       expect(params).to.deep.equal([condition.value.source])
@@ -306,7 +244,7 @@ describe('Condition Interpreter', () => {
 
     it('generates call to `REGEXP` function for MySQL', () => {
       const condition = new Field('regex', 'email', /@/)
-      const [sql, params] = interpret(condition, { ...mysql, joinRelation })
+      const [sql, params] = interpret(condition, { ...mysql })
 
       expect(sql).to.equal('`email` regexp ? = 1')
       expect(params).to.deep.equal([condition.value.source])
@@ -315,8 +253,53 @@ describe('Condition Interpreter', () => {
     it('throws exception for MSSQL as it does not support REGEXP', () => {
       const condition = new Field('regex', 'email', /@/)
       expect(() => {
-        interpret(condition, { ...mssql, joinRelation })
+        interpret(condition, { ...mssql })
       }).to.throw(/"regexp" operator is not supported in MSSQL/)
+    })
+  })
+
+  describe('relation conditions', () => {
+    const interpret = createSqlInterpreter({
+      eq,
+      some: someRelation,
+      every: everyRelation,
+      none: noneRelation
+    })
+    const condition = new Field('some', 'wallets', new Field('eq', 'balance', 5))
+
+    it('generates EXISTS query for simple relation metadata', () => {
+      const interpreterOptions: SqlQueryOptions = {
+        ...options,
+        rootAlias: 'users',
+        getRelationMetadata: () => ({
+          parentField: 'id',
+          relationField: 'userId',
+          relationTable: 'user_wallets',
+        })
+      }
+      const [sql, params] = interpret(condition, interpreterOptions)
+
+      expect(sql).to.equal('EXISTS (SELECT 1 FROM "user_wallets" as "wallets_0" WHERE "users"."id" = "wallets_0"."userId" AND ("wallets_0"."balance" = $1))')
+      expect(params).to.deep.equal([5])
+    })
+
+    it('allows custom relation SQL to add parameters before nested condition SQL', () => {
+      const interpreterOptions: SqlQueryOptions = {
+        ...options,
+        rootAlias: 'users',
+        getRelationMetadata: () => ({
+          buildRelationQuery(relation) {
+            return `SELECT 1 FROM ${relation.escapeField('wallets')} as ${relation.escapeField(relation.relationAlias)}` +
+            ` WHERE ${relation.parentField('id')} = ${relation.relationField('userId')}` +
+            ` AND ${relation.relationField('kind')} = ${relation.param('primary')}` +
+            ` AND (${relation.conditionSql()})`
+          }
+        })
+      }
+      const [sql, params] = interpret(condition, interpreterOptions)
+
+      expect(sql).to.equal('EXISTS (SELECT 1 FROM "wallets" as "wallets_0" WHERE "users"."id" = "wallets_0"."userId" AND "wallets_0"."kind" = $1 AND ("wallets_0"."balance" = $2))')
+      expect(params).to.deep.equal(['primary', 5])
     })
   })
 })

--- a/packages/sql/spec/mikro-orm.spec.ts
+++ b/packages/sql/spec/mikro-orm.spec.ts
@@ -1,19 +1,29 @@
 import { FieldCondition, CompoundCondition } from '@ucast/core'
 import { Collection, EntitySchema, MikroORM, QueryBuilder } from '@mikro-orm/sqlite'
-import { interpret } from '../src/lib/mikro-orm.ts'
+import { createInterpreter, getRelationMetadata, interpret } from '../src/lib/mikro-orm.ts'
 import { expect } from './specHelper.ts'
+import { eq, someRelation } from '../src/interpreters.ts'
+import {
+  expectedRelationNames,
+  namesOf,
+  relationConditions,
+  relationSeeds
+} from './relationTestsConfig.ts'
 
 type Depromisify<T extends Promise<any>> = T extends Promise<infer A> ? A : never
 type OrmContext = Depromisify<ReturnType<typeof configureORM>>
 
 describe('Condition interpreter for MikroORM', () => {
+  let ctx: OrmContext
   let orm: OrmContext['orm']
   let User: OrmContext['User']
+  let Project: OrmContext['Project']
 
   before(async () => {
-    const ctx = await configureORM()
+    ctx = await configureORM()
     orm = ctx.orm
     User = ctx.User
+    Project = ctx.Project
   })
 
   after(async () => {
@@ -25,58 +35,189 @@ describe('Condition interpreter for MikroORM', () => {
     const query = interpret(condition, orm.em.createQueryBuilder(User).select([]))
 
     expect(query).to.be.instanceof(QueryBuilder)
-    expect(query.getQuery()).to.equal('select * from `user` as `u0` where (`name` = ?)')
+    expect(query.getQuery()).to.equal('select * from `user` as `u0` where (`u0`.`name` = ?)')
   })
 
   it('properly binds parameters for "IN" operator', () => {
     const condition = new FieldCondition('in', 'age', [1, 2, 3])
     const query = interpret(condition, orm.em.createQueryBuilder(User).select([]))
 
-    expect(query.getQuery()).to.equal('select * from `user` as `u0` where (`age` in(?, ?, ?))')
+    expect(query.getQuery()).to.equal('select * from `user` as `u0` where (`u0`.`age` in(?, ?, ?))')
   })
 
-  it('automatically inner joins relation when condition is set on relation field', () => {
+  it('treats dotted field names as literal fields', () => {
     const condition = new FieldCondition('eq', 'projects.name', 'test')
     const query = interpret(condition, orm.em.createQueryBuilder(User).select([]))
 
-    expect(query.getQuery()).to.equal([
-      'select *',
-      'from `user` as `u0`',
-      'inner join `project` as `projects` on `u0`.`id` = `projects`.`user_id`',
-      'where (`projects`.`name` = ?)'
-    ].join(' '))
+    expect(query.getQuery()).to.equal('select * from `user` as `u0` where (`u0`.`projects.name` = ?)')
   })
 
-  it('should join the same relation exactly one time', () => {
+  it("doesn't auto join dotted fields in compound conditions", () => {
     const condition = new CompoundCondition('and', [
       new FieldCondition('eq', 'projects.name', 'test'),
       new FieldCondition('eq', 'projects.active', true),
     ])
     const query = interpret(condition, orm.em.createQueryBuilder(User).select([]))
 
+    expect(query.getQuery()).to.equal('select * from `user` as `u0` where ((`u0`.`projects.name` = ? and `u0`.`projects.active` = ?))')
+  })
+
+  it('generates nested EXISTS queries for nested relations', () => {
+    const condition = new FieldCondition(
+      'some',
+      'projects',
+      new FieldCondition(
+        'some',
+        'deadlines',
+        new FieldCondition('eq', 'date', '2026-06-28')
+      )
+    )
+    const query = interpret(condition, orm.em.createQueryBuilder(User).select([]))
+
     expect(query.getQuery()).to.equal([
-      'select *',
-      'from `user` as `u0`',
-      'inner join `project` as `projects` on `u0`.`id` = `projects`.`user_id`',
-      'where ((`projects`.`name` = ? and `projects`.`active` = ?))'
+      'select * from `user` as `u0`',
+      'where (EXISTS (SELECT 1 FROM `project` as `projects_0`',
+      'WHERE `u0`.`id` = `projects_0`.`user_id`',
+      'AND (EXISTS (SELECT 1 FROM `deadline` as `deadlines_1`',
+      'WHERE `projects_0`.`id` = `deadlines_1`.`project_id`',
+      'AND (`deadlines_1`.`date` = ?)))))'
     ].join(' '))
+  })
+
+  it('uses the pivot table for many-to-many relations', () => {
+    const condition = new FieldCondition(
+      'some',
+      'roles',
+      new FieldCondition('eq', 'name', 'admin')
+    )
+    const query = interpret(condition, orm.em.createQueryBuilder(User).select([]))
+    const sql = query.getQuery()
+
+    expect(sql).to.contain('SELECT 1 FROM `user_roles` as `roles_')
+    expect(sql).to.contain('_through` INNER JOIN `role` as `roles_')
+    expect(sql).to.contain('`.`id` = `roles_')
+    expect(sql).to.contain('_through`.`role_id`')
+    expect(sql).to.contain('`u0`.`id` = `roles_')
+    expect(sql).to.contain('_through`.`user_id`')
+    expect(sql).to.contain('`.`name` = ?')
+  })
+
+  it('allows custom relation SQL to add domain joins and parameters', () => {
+    const interpret = createInterpreter({ eq, some: someRelation }, {
+      getRelationMetadata(relationName, ctx) {
+        if (relationName !== 'projects') {
+          return getRelationMetadata(relationName, ctx)
+        }
+
+        return {
+          relationContext: orm.getMetadata().get(Project.name),
+          buildRelationQuery(relation) {
+            const tenantProjectAlias = 'tenant_projects'
+            const tenantProjectField = (field: string) => {
+              return `${relation.escapeField(tenantProjectAlias)}.${relation.escapeField(field)}`
+            }
+
+            return `SELECT 1 FROM ${relation.escapeField('tenant_projects')} as ${relation.escapeField(tenantProjectAlias)}` +
+            ` INNER JOIN ${relation.escapeField('project')} as ${relation.escapeField(relation.relationAlias)}` +
+            ` ON ${relation.relationField('id')} = ${tenantProjectField('project_id')}` +
+            ` WHERE ${relation.parentField('tenant_id')} = ${tenantProjectField('tenant_id')}` +
+            ` AND ${tenantProjectField('kind')} = ${relation.param('owned')}` +
+            ` AND (${relation.conditionSql()})`
+          }
+        }
+      }
+    })
+    const condition = new FieldCondition(
+      'some',
+      'projects',
+      new FieldCondition('eq', 'active', true)
+    )
+    const query = interpret(condition, orm.em.createQueryBuilder(User).select([]))
+
+    expect(query.getQuery()).to.contain('`tenant_projects`.`kind` = ? AND (')
+    expect(query.getQuery()).to.contain('`.`active` = ?')
+  })
+
+  describe('SQLite relation e2e', () => {
+    before(async () => {
+      await seedMikroOrm(ctx)
+    })
+
+    it('filters 1:m relations', async () => {
+      const users = await interpret(
+        relationConditions.hasMany,
+        orm.em.fork().createQueryBuilder(User).select([])
+      ).orderBy({ name: 'ASC' }).getResultList()
+
+      expect(namesOf(users)).to.deep.equal(expectedRelationNames.hasMany)
+    })
+
+    it('filters m:1 relations', async () => {
+      const projects = await interpret(
+        relationConditions.belongsTo,
+        orm.em.fork().createQueryBuilder(Project).select([])
+      ).orderBy({ name: 'ASC' }).getResultList()
+
+      expect(namesOf(projects)).to.deep.equal(expectedRelationNames.belongsTo)
+    })
+
+    it('filters 1:1 relations', async () => {
+      const users = await interpret(
+        relationConditions.hasOne,
+        orm.em.fork().createQueryBuilder(User).select([])
+      ).orderBy({ name: 'ASC' }).getResultList()
+
+      expect(namesOf(users)).to.deep.equal(expectedRelationNames.hasOne)
+    })
+
+    it('filters m:n relations', async () => {
+      const users = await interpret(
+        relationConditions.manyToMany,
+        orm.em.fork().createQueryBuilder(User).select([])
+      ).orderBy({ name: 'ASC' }).getResultList()
+
+      expect(namesOf(users)).to.deep.equal(expectedRelationNames.manyToMany)
+    })
   })
 })
 
 async function configureORM() {
   class User {
     public id: number
+    public tenantId: string
     public name: string
+    public profile?: Profile
     public projects?: Collection<Project>
+    public roles?: Collection<Role>
 
     constructor(
       id: number,
+      tenantId: string,
       name: string,
-      projects?: Collection<Project>
+      projects?: Collection<Project>,
+      roles?: Collection<Role>
     ) {
       this.id = id
+      this.tenantId = tenantId
       this.name = name
       this.projects = projects || new Collection<Project>(this)
+      this.roles = roles || new Collection<Role>(this)
+    }
+  }
+
+  class Profile {
+    public id: number
+    public displayName: string
+    public user: User
+
+    constructor(
+      id: number,
+      displayName: string,
+      user: User
+    ) {
+      this.id = id
+      this.displayName = displayName
+      this.user = user
     }
   }
 
@@ -85,17 +226,52 @@ async function configureORM() {
     public name: string
     public user: User
     public active: boolean
+    public deadlines?: Collection<Deadline>
 
     constructor(
       id: number,
       name: string,
       user: User,
-      active: boolean
+      active: boolean,
+      deadlines?: Collection<Deadline>
     ) {
       this.id = id
       this.name = name
       this.user = user
       this.active = active
+      this.deadlines = deadlines || new Collection<Deadline>(this)
+    }
+  }
+
+  class Deadline {
+    public id: number
+    public date: string
+    public project: Project
+
+    constructor(
+      id: number,
+      date: string,
+      project: Project
+    ) {
+      this.id = id
+      this.date = date
+      this.project = project
+    }
+  }
+
+  class Role {
+    public id: number
+    public name: string
+    public users?: Collection<User>
+
+    constructor(
+      id: number,
+      name: string,
+      users?: Collection<User>
+    ) {
+      this.id = id
+      this.name = name
+      this.users = users || new Collection<User>(this)
     }
   }
 
@@ -103,13 +279,42 @@ async function configureORM() {
     class: User,
     properties: {
       id: { type: 'number', primary: true },
+      tenantId: { type: 'string' },
       name: { type: 'string' },
+      profile: {
+        kind: '1:1',
+        entity: 'Profile',
+        ref: true,
+        nullable: true,
+        mappedBy: 'user'
+      },
       projects: {
         kind: '1:m',
         entity: 'Project',
         ref: true,
         nullable: false,
         mappedBy: 'user'
+      },
+      roles: {
+        kind: 'm:n',
+        entity: 'Role',
+        owner: true,
+        inversedBy: 'users',
+        pivotTable: 'user_roles'
+      }
+    }
+  })
+  const ProfileSchema = new EntitySchema({
+    class: Profile,
+    properties: {
+      id: { type: 'number', primary: true },
+      displayName: { type: 'string', fieldName: 'display_name' },
+      user: {
+        entity: 'User',
+        kind: '1:1',
+        owner: true,
+        ref: true,
+        nullable: false
       }
     }
   })
@@ -119,14 +324,94 @@ async function configureORM() {
       id: { type: 'number', primary: true },
       name: { type: 'string' },
       user: { entity: 'User', kind: 'm:1', ref: true, nullable: false },
-      active: { type: 'boolean' }
+      active: { type: 'boolean' },
+      deadlines: {
+        kind: '1:m',
+        entity: 'Deadline',
+        ref: true,
+        nullable: false,
+        mappedBy: 'project'
+      }
+    }
+  })
+  const DeadlineSchema = new EntitySchema({
+    class: Deadline,
+    properties: {
+      id: { type: 'number', primary: true },
+      date: { type: 'string' },
+      project: { entity: 'Project', kind: 'm:1', ref: true, nullable: false }
+    }
+  })
+  const RoleSchema = new EntitySchema({
+    class: Role,
+    properties: {
+      id: { type: 'number', primary: true },
+      name: { type: 'string' },
+      users: {
+        kind: 'm:n',
+        entity: 'User',
+        mappedBy: 'roles'
+      }
     }
   })
 
   const orm = await MikroORM.init({
-    entities: [UserSchema, ProjectSchema],
+    entities: [UserSchema, ProfileSchema, ProjectSchema, DeadlineSchema, RoleSchema],
     dbName: ':memory:',
   })
 
-  return { User, Project, orm }
+  return { Deadline, Profile, Project, Role, User, orm }
+}
+
+async function seedMikroOrm({
+  Deadline,
+  Profile,
+  Project,
+  Role,
+  User,
+  orm
+}: OrmContext) {
+  await orm.schema.createSchema()
+  const em = orm.em.fork()
+
+  const users = new Map(relationSeeds.users.map(user => [
+    user.id,
+    new User(user.id, user.tenantId, user.name),
+  ]))
+  const roles = new Map(relationSeeds.roles.map(role => [
+    role.id,
+    new Role(role.id, role.name),
+  ]))
+  const projects = relationSeeds.projects.map(project => new Project(
+    project.id,
+    project.name,
+    users.get(project.userId)!,
+    project.active
+  ))
+  const deadlines = relationSeeds.deadlines.map(deadline => new Deadline(
+    deadline.id,
+    deadline.date,
+    projects.find(project => project.id === deadline.projectId)!
+  ))
+  const profiles = relationSeeds.profiles.map(profile => {
+    const user = users.get(profile.userId)!
+    const entity = new Profile(profile.id, profile.displayName, user)
+
+    user.profile = entity
+    return entity
+  })
+
+  relationSeeds.userRoles.forEach(({ userId, roleId }) => {
+    users.get(userId)!.roles!.add(roles.get(roleId)!)
+  })
+
+  em.persist([
+    ...users.values(),
+    ...roles.values(),
+    ...profiles,
+    ...projects,
+    ...deadlines,
+  ])
+  await em.flush()
+  em.clear()
 }

--- a/packages/sql/spec/objection.spec.ts
+++ b/packages/sql/spec/objection.spec.ts
@@ -1,11 +1,19 @@
 import { FieldCondition, CompoundCondition } from '@ucast/core'
-import { Model, QueryBuilder } from 'objection'
+import { Model, QueryBuilder, snakeCaseMappers } from 'objection'
 import Knex from 'knex'
-import { interpret } from '../src/lib/objection.ts'
-import { expect, linearize } from './specHelper.ts'
+import { createInterpreter, getRelationMetadata, interpret } from '../src/lib/objection.ts'
+import { expect } from './specHelper.ts'
+import { eq, someRelation } from '../src/interpreters.ts'
+import {
+  expectedRelationNames,
+  namesOf,
+  relationConditions,
+  relationSeeds
+} from './relationTestsConfig.ts'
 
 describe('Condition interpreter for Objection', () => {
-  const { User } = configureORM()
+  const orm = configureORM()
+  const { Project, User } = orm
 
   it('returns `QueryBuilder`', () => {
     const condition = new FieldCondition('eq', 'name', 'test')
@@ -19,7 +27,7 @@ describe('Condition interpreter for Objection', () => {
     const query = interpret(condition, User.query())
 
     expect(query.toKnexQuery().toString()).to.equal(`
-      select "users".* from "users" where "name" = 'test'
+      select "users".* from "users" where "users"."name" = 'test'
     `.trim())
   })
 
@@ -28,23 +36,20 @@ describe('Condition interpreter for Objection', () => {
     const query = interpret(condition, User.query())
 
     expect(query.toKnexQuery().toString()).to.equal(`
-      select "users".* from "users" where "age" in(1, 2, 3)
+      select "users".* from "users" where "users"."age" in(1, 2, 3)
     `.trim())
   })
 
-  it('automatically inner joins relation when condition is set on relation field', () => {
+  it('treats dotted field names as literal fields', () => {
     const condition = new FieldCondition('eq', 'projects.name', 'test')
     const query = interpret(condition, User.query())
 
-    expect(query.toKnexQuery().toString()).to.equal(linearize`
-      select "users".*
-      from "users"
-        inner join "projects" on "projects"."user_id" = "users"."id"
-      where "projects"."name" = 'test'
+    expect(query.toKnexQuery().toString()).to.equal(`
+      select "users".* from "users" where "users"."projects.name" = 'test'
     `.trim())
   })
 
-  it('should join the same relation exactly one time', () => {
+  it("doesn't auto join dotted fields in compound conditions", () => {
     const condition = new CompoundCondition('and', [
       new FieldCondition('eq', 'projects.name', 'test'),
       new FieldCondition('eq', 'projects.active', true),
@@ -52,20 +57,138 @@ describe('Condition interpreter for Objection', () => {
 
     const query = interpret(condition, User.query())
 
-    expect(query.toKnexQuery().toString()).to.equal(linearize`
-      select "users".*
-      from "users"
-        inner join "projects" on "projects"."user_id" = "users"."id"
-      where ("projects"."name" = 'test' and "projects"."active" = true)
+    expect(query.toKnexQuery().toString()).to.equal(`
+      select "users".* from "users" where ("users"."projects.name" = 'test' and "users"."projects.active" = true)
     `.trim())
+  })
+
+  it('generates nested EXISTS queries for nested relations', () => {
+    const condition = new FieldCondition(
+      'some',
+      'projects',
+      new FieldCondition(
+        'some',
+        'deadlines',
+        new FieldCondition('eq', 'date', '2026-06-28')
+      )
+    )
+    const query = interpret(condition, User.query())
+
+    expect(query.toKnexQuery().toString()).to.equal(
+      'select "users".* from "users" where EXISTS (SELECT 1 FROM "projects" as "projects_0" ' +
+      'WHERE "users"."id" = "projects_0"."user_id" AND (EXISTS (SELECT 1 FROM "deadlines" as "deadlines_1" ' +
+      'WHERE "projects_0"."id" = "deadlines_1"."project_id" AND ("deadlines_1"."date" = \'2026-06-28\'))))'
+    )
+  })
+
+  it('uses the through table for many-to-many relations', () => {
+    const condition = new FieldCondition(
+      'some',
+      'roles',
+      new FieldCondition('eq', 'name', 'admin')
+    )
+    const query = interpret(condition, User.query())
+    const sql = query.toKnexQuery().toString()
+
+    expect(sql).to.contain('SELECT 1 FROM "user_roles" as "roles_')
+    expect(sql).to.contain('_through" INNER JOIN "roles" as "roles_')
+    expect(sql).to.contain('"."id" = "roles_')
+    expect(sql).to.contain('_through"."role_id"')
+    expect(sql).to.contain('"users"."id" = "roles_')
+    expect(sql).to.contain('_through"."user_id"')
+    expect(sql).to.contain('"."name" = \'admin\'')
+  })
+
+  it('allows custom relation SQL to add domain joins and parameters', () => {
+    const interpret = createInterpreter({ eq, some: someRelation }, {
+      getRelationMetadata(relationName, ctx) {
+        if (relationName !== 'projects') {
+          return getRelationMetadata(relationName, ctx)
+        }
+
+        return {
+          relationContext: Project,
+          buildRelationQuery(relation) {
+            const tenantProjectAlias = 'tenant_projects'
+            const tenantProjectField = (field: string) => {
+              return `${relation.escapeField(tenantProjectAlias)}.${relation.escapeField(field)}`
+            }
+
+            return `SELECT 1 FROM ${relation.escapeField('tenant_projects')} as ${relation.escapeField(tenantProjectAlias)}` +
+            ` INNER JOIN ${relation.escapeField('projects')} as ${relation.escapeField(relation.relationAlias)}` +
+            ` ON ${relation.relationField('id')} = ${tenantProjectField('project_id')}` +
+            ` WHERE ${relation.parentField('tenant_id')} = ${tenantProjectField('tenant_id')}` +
+            ` AND ${tenantProjectField('kind')} = ${relation.param('owned')}` +
+            ` AND (${relation.conditionSql()})`
+          }
+        }
+      }
+    })
+    const condition = new FieldCondition(
+      'some',
+      'projects',
+      new FieldCondition('eq', 'active', true)
+    )
+    const query = interpret(condition, User.query())
+
+    expect(query.toKnexQuery().toString()).to.contain('"tenant_projects"."kind" = \'owned\' AND (')
+    expect(query.toKnexQuery().toString()).to.contain('"."active" = true')
+  })
+
+  describe('SQLite relation e2e', () => {
+    let knex: ReturnType<typeof Knex>
+
+    before(async () => {
+      knex = Knex({
+        client: 'sqlite3',
+        connection: { filename: ':memory:' },
+        useNullAsDefault: true,
+      })
+      Model.knex(knex)
+      await createObjectionSchema(knex)
+      await seedObjection(orm)
+    })
+
+    after(async () => {
+      await knex.destroy()
+    })
+
+    it('filters HasMany relations', async () => {
+      const users = await interpret(relationConditions.hasMany, User.query()).orderBy('name')
+
+      expect(namesOf(users)).to.deep.equal(expectedRelationNames.hasMany)
+    })
+
+    it('filters BelongsToOne relations', async () => {
+      const projects = await interpret(relationConditions.belongsTo, Project.query()).orderBy('name')
+
+      expect(namesOf(projects)).to.deep.equal(expectedRelationNames.belongsTo)
+    })
+
+    it('filters HasOne relations', async () => {
+      const users = await interpret(relationConditions.hasOne, User.query()).orderBy('name')
+
+      expect(namesOf(users)).to.deep.equal(expectedRelationNames.hasOne)
+    })
+
+    it('filters ManyToMany relations', async () => {
+      const users = await interpret(relationConditions.manyToMany, User.query()).orderBy('name')
+
+      expect(namesOf(users)).to.deep.equal(expectedRelationNames.manyToMany)
+    })
   })
 })
 
 function configureORM() {
   Model.knex(Knex({ client: 'pg' }))
 
-  class User extends Model {
+  class BaseModel extends Model {
+    static columnNameMappers = snakeCaseMappers()
+  }
+
+  class User extends BaseModel {
     static tableName = 'users'
+    name!: string
 
     static get relationMappings() {
       return {
@@ -73,25 +196,163 @@ function configureORM() {
           relation: Model.HasManyRelation,
           modelClass: Project,
           join: { from: 'users.id', to: 'projects.user_id' }
+        },
+        profile: {
+          relation: Model.HasOneRelation,
+          modelClass: Profile,
+          join: { from: 'users.id', to: 'profiles.user_id' }
+        },
+        roles: {
+          relation: Model.ManyToManyRelation,
+          modelClass: Role,
+          join: {
+            from: 'users.id',
+            through: {
+              from: 'user_roles.user_id',
+              to: 'user_roles.role_id'
+            },
+            to: 'roles.id'
+          }
         }
       }
     }
   }
 
-  class Project extends Model {
-    static tableName = 'projects'
+  class Profile extends BaseModel {
+    static tableName = 'profiles'
+    displayName!: string
 
     static get relationMappings() {
       return {
         user: {
           relation: Model.BelongsToOneRelation,
           modelClass: User,
-          join: { from: 'users.id', to: 'projects.user_id' },
-          active: Boolean
+          join: { from: 'profiles.user_id', to: 'users.id' }
         }
       }
     }
   }
 
-  return { User, Project }
+  class Project extends BaseModel {
+    static tableName = 'projects'
+    name!: string
+
+    static get relationMappings() {
+      return {
+        user: {
+          relation: Model.BelongsToOneRelation,
+          modelClass: User,
+          join: { from: 'projects.user_id', to: 'users.id' },
+          active: Boolean
+        },
+        deadlines: {
+          relation: Model.HasManyRelation,
+          modelClass: Deadline,
+          join: { from: 'projects.id', to: 'deadlines.project_id' }
+        }
+      }
+    }
+  }
+
+  class Deadline extends BaseModel {
+    static tableName = 'deadlines'
+
+    static get relationMappings() {
+      return {
+        project: {
+          relation: Model.BelongsToOneRelation,
+          modelClass: Project,
+          join: { from: 'deadlines.project_id', to: 'projects.id' }
+        }
+      }
+    }
+  }
+
+  class Role extends BaseModel {
+    static tableName = 'roles'
+
+    static get relationMappings() {
+      return {
+        users: {
+          relation: Model.ManyToManyRelation,
+          modelClass: User,
+          join: {
+            from: 'roles.id',
+            through: {
+              from: 'user_roles.role_id',
+              to: 'user_roles.user_id'
+            },
+            to: 'users.id'
+          }
+        }
+      }
+    }
+  }
+
+  class UserRole extends BaseModel {
+    static tableName = 'user_roles'
+  }
+
+  return { Deadline, Profile, Project, Role, User, UserRole }
+}
+
+async function createObjectionSchema(knex: ReturnType<typeof Knex>) {
+  await knex.schema.createTable('users', table => {
+    table.integer('id').primary()
+    table.string('tenant_id').notNullable()
+    table.string('name').notNullable()
+  })
+  await knex.schema.createTable('profiles', table => {
+    table.integer('id').primary()
+    table.integer('user_id').notNullable().references('users.id')
+    table.string('display_name').notNullable()
+  })
+  await knex.schema.createTable('projects', table => {
+    table.integer('id').primary()
+    table.integer('user_id').notNullable().references('users.id')
+    table.string('name').notNullable()
+    table.boolean('active').notNullable()
+  })
+  await knex.schema.createTable('deadlines', table => {
+    table.integer('id').primary()
+    table.integer('project_id').notNullable().references('projects.id')
+    table.string('date').notNullable()
+  })
+  await knex.schema.createTable('roles', table => {
+    table.integer('id').primary()
+    table.string('name').notNullable()
+  })
+  await knex.schema.createTable('user_roles', table => {
+    table.integer('user_id').notNullable().references('users.id')
+    table.integer('role_id').notNullable().references('roles.id')
+    table.primary(['user_id', 'role_id'])
+  })
+}
+
+async function seedObjection({
+  Deadline,
+  Profile,
+  Project,
+  Role,
+  User,
+  UserRole,
+}: ReturnType<typeof configureORM>) {
+  for (const user of relationSeeds.users) {
+    await User.query().insert(user)
+  }
+  for (const profile of relationSeeds.profiles) {
+    await Profile.query().insert(profile)
+  }
+  for (const project of relationSeeds.projects) {
+    await Project.query().insert(project)
+  }
+  for (const deadline of relationSeeds.deadlines) {
+    await Deadline.query().insert(deadline)
+  }
+  for (const role of relationSeeds.roles) {
+    await Role.query().insert(role)
+  }
+  for (const userRole of relationSeeds.userRoles) {
+    await UserRole.query().insert(userRole)
+  }
 }

--- a/packages/sql/spec/relationTestsConfig.ts
+++ b/packages/sql/spec/relationTestsConfig.ts
@@ -1,0 +1,52 @@
+import { FieldCondition } from '@ucast/core'
+
+export const relationSeeds = {
+  users: [
+    { id: 1, tenantId: 'tenant-a', name: 'Alice' },
+    { id: 2, tenantId: 'tenant-a', name: 'Bob' },
+    { id: 3, tenantId: 'tenant-b', name: 'Carol' },
+  ],
+  profiles: [
+    { id: 1, userId: 1, displayName: 'Alice Profile' },
+    { id: 2, userId: 2, displayName: 'Bob Profile' },
+  ],
+  projects: [
+    { id: 1, userId: 1, name: 'Launch', active: true },
+    { id: 2, userId: 1, name: 'Archive', active: false },
+    { id: 3, userId: 2, name: 'Audit', active: true },
+    { id: 4, userId: 3, name: 'Migration', active: false },
+  ],
+  deadlines: [
+    { id: 1, projectId: 1, date: '2026-06-28' },
+    { id: 2, projectId: 3, date: '2026-07-01' },
+  ],
+  roles: [
+    { id: 1, name: 'admin' },
+    { id: 2, name: 'editor' },
+    { id: 3, name: 'viewer' },
+  ],
+  userRoles: [
+    { userId: 1, roleId: 1 },
+    { userId: 1, roleId: 2 },
+    { userId: 2, roleId: 2 },
+    { userId: 3, roleId: 3 },
+  ],
+}
+
+export const relationConditions = {
+  hasMany: new FieldCondition('some', 'projects', new FieldCondition('eq', 'name', 'Audit')),
+  belongsTo: new FieldCondition('some', 'user', new FieldCondition('eq', 'name', 'Bob')),
+  hasOne: new FieldCondition('some', 'profile', new FieldCondition('eq', 'display_name', 'Alice Profile')),
+  manyToMany: new FieldCondition('some', 'roles', new FieldCondition('eq', 'name', 'admin')),
+}
+
+export const expectedRelationNames = {
+  hasMany: ['Bob'],
+  belongsTo: ['Audit'],
+  hasOne: ['Alice'],
+  manyToMany: ['Alice'],
+}
+
+export function namesOf(records: { name: string }[]) {
+  return records.map(record => record.name).sort()
+}

--- a/packages/sql/spec/sequelize.spec.ts
+++ b/packages/sql/spec/sequelize.spec.ts
@@ -1,48 +1,142 @@
-import { FieldCondition, CompoundCondition } from '@ucast/core'
+import { FieldCondition } from '@ucast/core'
 import { Model, Sequelize, DataTypes } from 'sequelize'
-import { interpret } from '../src/lib/sequelize.ts'
+import { createInterpreter, getRelationMetadata, interpret } from '../src/lib/sequelize.ts'
 import { expect } from './specHelper.ts'
+import { eq, someRelation } from '../src/interpreters.ts'
+import {
+  expectedRelationNames,
+  namesOf,
+  relationConditions,
+  relationSeeds
+} from './relationTestsConfig.ts'
 
 describe('Condition interpreter for Sequelize', () => {
-  const { User } = configureORM()
+  const orm = configureORM()
+  const { Project, User, sequelize } = orm
 
-  it('returns an object with `where` and `include` keys', () => {
-    const condition = new FieldCondition('eq', 'name', 'test')
-    const query = interpret(condition, User)
-
-    expect(query).to.be.an('object')
-    expect(query.where.val).to.equal('`name` = \'test\'')
-    expect(query.include).to.be.an('array').that.is.empty
+  after(async () => {
+    await sequelize.close()
   })
 
-  it('properly binds parameters for "IN" operator', () => {
-    const condition = new FieldCondition('in', 'age', [1, 2, 3])
+  it('generates nested EXISTS queries for nested relations', () => {
+    const condition = new FieldCondition(
+      'some',
+      'projects',
+      new FieldCondition(
+        'some',
+        'deadlines',
+        new FieldCondition('eq', 'date', '2026-06-28')
+      )
+    )
+
     const query = interpret(condition, User)
 
-    expect(query.where.val).to.equal('`age` in(1, 2, 3)')
+    expect(query.where.val).to.equal(
+      "EXISTS (SELECT 1 FROM `projects` as `projects_0` WHERE `users`.`id` = `projects_0`.`userId` " +
+      "AND (EXISTS (SELECT 1 FROM `deadlines` as `deadlines_1` WHERE `projects_0`.`id` = `deadlines_1`.`projectId` " +
+      "AND (`deadlines_1`.`date` = '2026-06-28'))))"
+    )
   })
 
-  it('automatically inner joins relation when condition is set on relation field', () => {
-    const condition = new FieldCondition('eq', 'projects.name', 'test')
-    const query = interpret(condition, User)
+  it('uses the through table for BelongsToMany relations', () => {
+    const condition = new FieldCondition(
+      'some',
+      'roles',
+      new FieldCondition('eq', 'name', 'admin')
+    )
 
-    expect(query.include).to.deep.equal([
-      { association: 'projects', required: true }
-    ])
-    expect(query.where.val).to.equal('`projects`.`name` = \'test\'')
+    const query = interpret(condition, User)
+    const sql = query.where.val
+
+    expect(sql).to.contain('SELECT 1 FROM `user_roles` as `roles_')
+    expect(sql).to.contain('_through` INNER JOIN `roles` as `roles_')
+    expect(sql).to.contain('`.`id` = `roles_')
+    expect(sql).to.contain('_through`.`roleId`')
+    expect(sql).to.contain('`users`.`id` = `roles_')
+    expect(sql).to.contain('_through`.`userId`')
+    expect(sql).to.contain("`.`name` = 'admin'")
   })
 
-  it('should join the same relation exactly one time', () => {
-    const condition = new CompoundCondition('and', [
-      new FieldCondition('eq', 'projects.name', 'test'),
-      new FieldCondition('eq', 'projects.active', true),
-    ])
+  it('allows custom relation SQL to add domain joins and parameters', () => {
+    const interpret = createInterpreter({ eq, some: someRelation }, {
+      getRelationMetadata(relationName, ctx) {
+        if (relationName !== 'projects') {
+          return getRelationMetadata(relationName, ctx)
+        }
 
+        return {
+          relationContext: Project,
+          buildRelationQuery(relation) {
+            const tenantProjectAlias = 'tenant_projects'
+            const tenantProjectField = (field: string) => {
+              return `${relation.escapeField(tenantProjectAlias)}.${relation.escapeField(field)}`
+            }
+
+            return `SELECT 1 FROM ${relation.escapeField('tenant_projects')} as ${relation.escapeField(tenantProjectAlias)}` +
+            ` INNER JOIN ${relation.escapeField('projects')} as ${relation.escapeField(relation.relationAlias)}` +
+            ` ON ${relation.relationField('id')} = ${tenantProjectField('projectId')}` +
+            ` WHERE ${relation.parentField('tenantId')} = ${tenantProjectField('tenantId')}` +
+            ` AND ${tenantProjectField('kind')} = ${relation.param('owned')}` +
+            ` AND (${relation.conditionSql()})`
+          }
+        }
+      }
+    })
+    const condition = new FieldCondition(
+      'some',
+      'projects',
+      new FieldCondition('eq', 'active', true)
+    )
     const query = interpret(condition, User)
-    expect(query.include).to.deep.equal([
-      { association: 'projects', required: true }
-    ])
-    expect(query.where.val).to.equal('(`projects`.`name` = \'test\' and `projects`.`active` = 1)')
+
+    expect(query.where.val).to.contain("`tenant_projects`.`kind` = 'owned' AND (")
+    expect(query.where.val).to.contain('`.`active` = 1')
+  })
+
+  describe('SQLite relation e2e', () => {
+    before(async () => {
+      await seedSequelize(orm)
+    })
+
+    it('filters HasMany relations', async () => {
+      const users = await User.findAll({
+        ...interpret(relationConditions.hasMany, User, { rootAlias: 'user' }),
+        order: [['name', 'ASC']],
+        raw: true,
+      })
+
+      expect(namesOf(users)).to.deep.equal(expectedRelationNames.hasMany)
+    })
+
+    it('filters BelongsTo relations', async () => {
+      const projects = await Project.findAll({
+        ...interpret(relationConditions.belongsTo, Project, { rootAlias: 'project' }),
+        order: [['name', 'ASC']],
+        raw: true,
+      })
+
+      expect(namesOf(projects)).to.deep.equal(expectedRelationNames.belongsTo)
+    })
+
+    it('filters HasOne relations', async () => {
+      const users = await User.findAll({
+        ...interpret(relationConditions.hasOne, User, { rootAlias: 'user' }),
+        order: [['name', 'ASC']],
+        raw: true,
+      })
+
+      expect(namesOf(users)).to.deep.equal(expectedRelationNames.hasOne)
+    })
+
+    it('filters BelongsToMany relations', async () => {
+      const users = await User.findAll({
+        ...interpret(relationConditions.manyToMany, User, { rootAlias: 'user' }),
+        order: [['name', 'ASC']],
+        raw: true,
+      })
+
+      expect(namesOf(users)).to.deep.equal(expectedRelationNames.manyToMany)
+    })
   })
 })
 
@@ -53,21 +147,84 @@ function configureORM() {
     logging: false,
   })
 
-  class User extends Model {}
-  class Project extends Model {}
+  class User extends Model {
+    name!: string
+  }
+  class Profile extends Model {}
+  class Project extends Model {
+    name!: string
+  }
+  class Deadline extends Model {}
+  class Role extends Model {}
+  class UserRole extends Model {}
 
   User.init({
+    tenantId: { type: DataTypes.STRING },
     name: { type: DataTypes.STRING },
     email: { type: DataTypes.STRING },
   }, { sequelize, modelName: 'user' })
+
+  Profile.init({
+    displayName: { type: DataTypes.STRING, field: 'display_name' },
+  }, { sequelize, modelName: 'profile' })
 
   Project.init({
     name: { type: DataTypes.STRING },
     active: { type: DataTypes.BOOLEAN }
   }, { sequelize, modelName: 'project' })
 
-  Project.belongsTo(User)
-  User.hasMany(Project)
+  Deadline.init({
+    date: { type: DataTypes.DATE }
+  }, { sequelize, modelName: 'deadline' })
 
-  return { User, Project }
+  Role.init({
+    name: { type: DataTypes.STRING }
+  }, { sequelize, modelName: 'role' })
+
+  UserRole.init({}, {
+    sequelize,
+    modelName: 'userRole',
+    tableName: 'user_roles',
+    timestamps: false,
+  })
+
+  User.hasOne(Profile, { as: 'profile', foreignKey: 'userId' })
+  Profile.belongsTo(User, { as: 'user', foreignKey: 'userId' })
+
+  Project.hasMany(Deadline, { as: 'deadlines', foreignKey: 'projectId' })
+  Deadline.belongsTo(Project, { as: 'project', foreignKey: 'projectId' })
+
+  Project.belongsTo(User, { as: 'user', foreignKey: 'userId' })
+  User.hasMany(Project, { as: 'projects', foreignKey: 'userId' })
+  User.belongsToMany(Role, {
+    through: UserRole,
+    as: 'roles',
+    foreignKey: 'userId',
+    otherKey: 'roleId',
+  })
+  Role.belongsToMany(User, {
+    through: UserRole,
+    as: 'users',
+    foreignKey: 'roleId',
+    otherKey: 'userId',
+  })
+
+  return { Deadline, Profile, Project, Role, User, sequelize }
+}
+
+async function seedSequelize({
+  Deadline,
+  Profile,
+  Project,
+  Role,
+  User,
+  sequelize,
+}: ReturnType<typeof configureORM>) {
+  await sequelize.sync({ force: true })
+  await User.bulkCreate(relationSeeds.users)
+  await Profile.bulkCreate(relationSeeds.profiles)
+  await Project.bulkCreate(relationSeeds.projects)
+  await Deadline.bulkCreate(relationSeeds.deadlines)
+  await Role.bulkCreate(relationSeeds.roles)
+  await sequelize.getQueryInterface().bulkInsert('user_roles', relationSeeds.userRoles)
 }

--- a/packages/sql/spec/typeorm.spec.ts
+++ b/packages/sql/spec/typeorm.spec.ts
@@ -1,11 +1,18 @@
-import { FieldCondition, CompoundCondition } from '@ucast/core'
+import { FieldCondition } from '@ucast/core'
 import {
   EntitySchema,
   createConnection,
   SelectQueryBuilder
 } from 'typeorm'
-import { interpret } from '../src/lib/typeorm.ts'
+import { createInterpreter, getRelationMetadata, interpret } from '../src/lib/typeorm.ts'
 import { expect } from './specHelper.ts'
+import { eq, someRelation } from '../src/interpreters.ts'
+import {
+  expectedRelationNames,
+  namesOf,
+  relationConditions,
+  relationSeeds
+} from './relationTestsConfig.ts'
 
 type Depromisify<T extends Promise<any>> = T extends Promise<infer A> ? A : never
 type OrmContext = Depromisify<ReturnType<typeof configureORM>>
@@ -13,11 +20,13 @@ type OrmContext = Depromisify<ReturnType<typeof configureORM>>
 describe('Condition interpreter for TypeORM', () => {
   let conn: OrmContext['conn']
   let User: OrmContext['User']
+  let Project: OrmContext['Project']
 
   before(async () => {
     const ctx = await configureORM()
     conn = ctx.conn
     User = ctx.User
+    Project = ctx.Project
   })
 
   after(async () => {
@@ -30,9 +39,9 @@ describe('Condition interpreter for TypeORM', () => {
 
     expect(query).to.be.instanceof(SelectQueryBuilder)
     expect(query.getQuery()).to.equal([
-      'SELECT "u"."id" AS "u_id", "u"."name" AS "u_name"',
+      'SELECT "u"."id" AS "u_id", "u"."tenantId" AS "u_tenantId", "u"."name" AS "u_name"',
       'FROM "user" "u"',
-      'WHERE "name" = :0'
+      'WHERE "u"."name" = :0'
     ].join(' '))
     expect(query.getParameters()).to.eql({ 0: 'test' })
   })
@@ -42,9 +51,9 @@ describe('Condition interpreter for TypeORM', () => {
     const query = interpret(condition, conn.createQueryBuilder(User, 'u'))
 
     expect(query.getQuery()).to.equal([
-      'SELECT "u"."id" AS "u_id", "u"."name" AS "u_name"',
+      'SELECT "u"."id" AS "u_id", "u"."tenantId" AS "u_tenantId", "u"."name" AS "u_name"',
       'FROM "user" "u"',
-      'WHERE "age" in(:0, :1, :2)'
+      'WHERE "u"."age" in(:0, :1, :2)'
     ].join(' '))
 
     expect(query.getParameters()).to.eql({
@@ -54,41 +63,159 @@ describe('Condition interpreter for TypeORM', () => {
     })
   })
 
-  it('automatically inner joins relation when condition is set on relation field', () => {
+  it('treats dotted field names as literal fields', () => {
     const condition = new FieldCondition('eq', 'projects.name', 'test')
     const query = interpret(condition, conn.createQueryBuilder(User, 'u'))
 
     expect(query.getQuery()).to.equal([
-      'SELECT "u"."id" AS "u_id", "u"."name" AS "u_name"',
+      'SELECT "u"."id" AS "u_id", "u"."tenantId" AS "u_tenantId", "u"."name" AS "u_name"',
       'FROM "user" "u"',
-      'INNER JOIN "project" "projects" ON "projects"."userId"="u"."id"',
-      'WHERE "projects"."name" = :0'
+      'WHERE "u"."projects.name" = :0'
     ].join(' '))
     expect(query.getParameters()).to.eql({ 0: 'test' })
   })
 
-  it("shouldn't join the same relation several times", () => {
-    const condition = new CompoundCondition('and', [
-      new FieldCondition('eq', 'projects.name', 'test'),
-      new FieldCondition('eq', 'projects.active', true),
-    ])
+  it('generates nested EXISTS queries for nested relations', () => {
+    const condition = new FieldCondition(
+      'some',
+      'projects',
+      new FieldCondition(
+        'some',
+        'deadlines',
+        new FieldCondition('eq', 'date', '2026-06-28')
+      )
+    )
     const query = interpret(condition, conn.createQueryBuilder(User, 'u'))
 
     expect(query.getQuery()).to.equal([
-      'SELECT "u"."id" AS "u_id", "u"."name" AS "u_name"',
+      'SELECT "u"."id" AS "u_id", "u"."tenantId" AS "u_tenantId", "u"."name" AS "u_name"',
       'FROM "user" "u"',
-      'INNER JOIN "project" "projects" ON "projects"."userId"="u"."id"',
-      'WHERE ("projects"."name" = :0 and "projects"."active" = :1)'
+      'WHERE EXISTS (' +
+        'SELECT 1 FROM "project" as "projects_0"',
+        'WHERE "u"."id" = "projects_0"."userId"',
+        'AND (EXISTS (' +
+          'SELECT 1 FROM "deadline" as "deadlines_1"',
+          'WHERE "projects_0"."id" = "deadlines_1"."projectId"',
+          'AND ("deadlines_1"."date" = :0)' +
+        '))' +
+      ')'
     ].join(' '))
-    expect(query.getParameters()).to.eql({ 0: 'test', 1: true })
+    expect(query.getParameters()).to.eql({ 0: '2026-06-28' })
+  })
+
+  it('uses the through table for many-to-many relations', () => {
+    const condition = new FieldCondition(
+      'some',
+      'roles',
+      new FieldCondition('eq', 'name', 'admin')
+    )
+    const query = interpret(condition, conn.createQueryBuilder(User, 'u'))
+    const sql = query.getQuery()
+
+    expect(sql).to.contain('SELECT 1 FROM "user_roles" as "roles_')
+    expect(sql).to.contain('_through" INNER JOIN "role" as "roles_')
+    expect(sql).to.contain('"."id" = "roles_')
+    expect(sql).to.contain('_through"."roleId"')
+    expect(sql).to.contain('"u"."id" = "roles_')
+    expect(sql).to.contain('_through"."userId"')
+    expect(sql).to.contain('"."name" = :0')
+    expect(query.getParameters()).to.eql({ 0: 'admin' })
+  })
+
+  it('allows custom relation SQL to add domain joins and parameters', () => {
+    const interpret = createInterpreter({ eq, some: someRelation }, {
+      getRelationMetadata(relationName, ctx) {
+        if (relationName !== 'projects') {
+          return getRelationMetadata(relationName, ctx)
+        }
+
+        return {
+          relationContext: conn.getMetadata(Project),
+          buildRelationQuery(relation) {
+            const tenantProjectAlias = 'tenant_projects'
+            const tenantProjectField = (field: string) => {
+              return `${relation.escapeField(tenantProjectAlias)}.${relation.escapeField(field)}`
+            }
+
+            return `SELECT 1 FROM ${relation.escapeField('tenant_projects')} as ${relation.escapeField(tenantProjectAlias)}` +
+            ` INNER JOIN ${relation.escapeField('project')} as ${relation.escapeField(relation.relationAlias)}` +
+            ` ON ${relation.relationField('id')} = ${tenantProjectField('projectId')}` +
+            ` WHERE ${relation.parentField('tenantId')} = ${tenantProjectField('tenantId')}` +
+            ` AND ${tenantProjectField('kind')} = ${relation.param('owned')}` +
+            ` AND (${relation.conditionSql()})`
+          }
+        }
+      }
+    })
+    const condition = new FieldCondition(
+      'some',
+      'projects',
+      new FieldCondition('eq', 'active', true)
+    )
+    const query = interpret(condition, conn.createQueryBuilder(User, 'u'))
+
+    expect(query.getQuery()).to.contain('"tenant_projects"."kind" = :0 AND (')
+    expect(query.getQuery()).to.contain('"."active" = :1')
+    expect(query.getParameters()).to.eql({ 0: 'owned', 1: true })
+  })
+
+  describe('SQLite relation e2e', () => {
+    before(async () => {
+      await seedTypeOrm(conn)
+    })
+
+    it('filters one-to-many relations', async () => {
+      const users = await interpret(
+        relationConditions.hasMany,
+        conn.createQueryBuilder(User, 'u')
+      ).orderBy('u.name', 'ASC').getMany()
+
+      expect(namesOf(users)).to.deep.equal(expectedRelationNames.hasMany)
+    })
+
+    it('filters many-to-one relations', async () => {
+      const projects = await interpret(
+        relationConditions.belongsTo,
+        conn.createQueryBuilder(Project, 'p')
+      ).orderBy('p.name', 'ASC').getMany()
+
+      expect(namesOf(projects)).to.deep.equal(expectedRelationNames.belongsTo)
+    })
+
+    it('filters one-to-one relations', async () => {
+      const users = await interpret(
+        relationConditions.hasOne,
+        conn.createQueryBuilder(User, 'u')
+      ).orderBy('u.name', 'ASC').getMany()
+
+      expect(namesOf(users)).to.deep.equal(expectedRelationNames.hasOne)
+    })
+
+    it('filters many-to-many relations', async () => {
+      const users = await interpret(
+        relationConditions.manyToMany,
+        conn.createQueryBuilder(User, 'u')
+      ).orderBy('u.name', 'ASC').getMany()
+
+      expect(namesOf(users)).to.deep.equal(expectedRelationNames.manyToMany)
+    })
   })
 })
 
 async function configureORM() {
   class User {
     id!: number
+    tenantId!: string
     name!: string
+    profile!: Profile
     projects!: Project[]
+    roles!: Role[]
+  }
+
+  class Profile {
+    id!: number
+    displayName!: string
+    user!: User
   }
 
   class Project {
@@ -96,6 +223,19 @@ async function configureORM() {
     name!: string
     user!: User
     active!: boolean
+    deadlines!: Deadline[]
+  }
+
+  class Deadline {
+    id!: number
+    date!: string
+    project!: Project
+  }
+
+  class Role {
+    id!: number
+    name!: string
+    users!: User[]
   }
 
   const UserSchema = new EntitySchema<User>({
@@ -103,13 +243,41 @@ async function configureORM() {
     target: User,
     columns: {
       id: { primary: true, type: 'int', generated: true },
+      tenantId: { type: 'varchar' },
       name: { type: 'varchar' },
     },
     relations: {
+      profile: {
+        target: 'Profile',
+        type: 'one-to-one',
+        inverseSide: 'user'
+      },
       projects: {
         target: 'Project',
         type: 'one-to-many',
         inverseSide: 'user'
+      },
+      roles: {
+        target: 'Role',
+        type: 'many-to-many',
+        joinTable: { name: 'user_roles' },
+        inverseSide: 'users'
+      }
+    }
+  })
+
+  const ProfileSchema = new EntitySchema<Profile>({
+    name: 'Profile',
+    target: Profile,
+    columns: {
+      id: { primary: true, type: 'int', generated: true },
+      displayName: { type: 'varchar', name: 'display_name' }
+    },
+    relations: {
+      user: {
+        target: 'User',
+        type: 'one-to-one',
+        joinColumn: { name: 'userId' }
       }
     }
   })
@@ -123,15 +291,73 @@ async function configureORM() {
       active: { type: 'boolean' }
     },
     relations: {
-      user: { target: 'User', type: 'many-to-one' }
+      user: { target: 'User', type: 'many-to-one' },
+      deadlines: {
+        target: 'Deadline',
+        type: 'one-to-many',
+        inverseSide: 'project'
+      }
+    }
+  })
+
+  const DeadlineSchema = new EntitySchema<Deadline>({
+    name: 'Deadline',
+    target: Deadline,
+    columns: {
+      id: { primary: true, type: 'int', generated: true },
+      date: { type: 'varchar' }
+    },
+    relations: {
+      project: { target: 'Project', type: 'many-to-one' }
+    }
+  })
+
+  const RoleSchema = new EntitySchema<Role>({
+    name: 'Role',
+    target: Role,
+    columns: {
+      id: { primary: true, type: 'int', generated: true },
+      name: { type: 'varchar' }
+    },
+    relations: {
+      users: {
+        target: 'User',
+        type: 'many-to-many',
+        inverseSide: 'roles'
+      }
     }
   })
 
   const conn = await createConnection({
     type: 'sqlite',
     database: ':memory:',
-    entities: [UserSchema, ProjectSchema]
+    entities: [UserSchema, ProfileSchema, ProjectSchema, DeadlineSchema, RoleSchema]
   })
 
   return { User, Project, conn }
+}
+
+async function seedTypeOrm(conn: OrmContext['conn']) {
+  await conn.synchronize(true)
+  await conn.createQueryBuilder().insert().into('user').values(relationSeeds.users).execute()
+  for (const profile of relationSeeds.profiles) {
+    await conn.query(
+      'INSERT INTO "profile" ("id", "userId", "display_name") VALUES (?, ?, ?)',
+      [profile.id, profile.userId, profile.displayName]
+    )
+  }
+  for (const project of relationSeeds.projects) {
+    await conn.query(
+      'INSERT INTO "project" ("id", "userId", "name", "active") VALUES (?, ?, ?, ?)',
+      [project.id, project.userId, project.name, project.active]
+    )
+  }
+  for (const deadline of relationSeeds.deadlines) {
+    await conn.query(
+      'INSERT INTO "deadline" ("id", "projectId", "date") VALUES (?, ?, ?)',
+      [deadline.id, deadline.projectId, deadline.date]
+    )
+  }
+  await conn.createQueryBuilder().insert().into('role').values(relationSeeds.roles).execute()
+  await conn.createQueryBuilder().insert().into('user_roles').values(relationSeeds.userRoles).execute()
 }

--- a/packages/sql/src/defaults.ts
+++ b/packages/sql/src/defaults.ts
@@ -3,4 +3,9 @@ import * as interpreters from './interpreters.ts';
 export const allInterpreters = {
   ...interpreters,
   in: interpreters.within,
+  some: interpreters.someRelation,
+  none: interpreters.noneRelation,
+  every: interpreters.everyRelation,
+  is: interpreters.isRelation,
+  isNot: interpreters.isNotRelation,
 };

--- a/packages/sql/src/index.ts
+++ b/packages/sql/src/index.ts
@@ -1,4 +1,5 @@
 export * from './interpreters.ts';
 export * from './interpreter.ts';
+export * from './relationUtils.ts';
 export * from './defaults.ts';
 export * from './dialects.ts';

--- a/packages/sql/src/interpreter.ts
+++ b/packages/sql/src/interpreter.ts
@@ -7,17 +7,50 @@ import {
 import { type DialectOptions } from './dialects.ts';
 
 export interface SqlQueryOptions extends Required<DialectOptions> {
-  rootAlias?: string
-  foreignField?(field: string, relationName: string): string
-  localField?(field: string): string
-  joinRelation?(relationName: string, context: unknown): boolean
+  rootAlias?: string;
+  localField?(field: string): string;
+  getRelationMetadata?(
+    relationName: string,
+    helpers: RelationMetadataHelpers
+  ): RelationMetadata | undefined;
+}
+
+export interface RelationMetadataHelpers {
+  escape(field: string): string;
+  relationContext: unknown;
+}
+
+export type RelationMetadata = SimpleRelationMetadata | CustomRelationMetadata;
+
+export interface SimpleRelationMetadata {
+  parentField: string;
+  relationField: string;
+  relationTable: string;
+  relationContext?: unknown;
+}
+
+export interface CustomRelationMetadata {
+  relationContext?: unknown;
+  buildRelationQuery(context: RelationQueryContext): string;
+}
+
+export interface RelationQueryContext {
+  relationName: string;
+  parentAlias?: string;
+  relationAlias: string;
+  escapeField(field: string): string;
+  parentField(field: string): string;
+  relationField(field: string): string;
+  conditionSql(): string;
+  param(value: unknown): string;
 }
 
 type ChildOptions = Partial<Pick<
 SqlQueryOptions,
-'foreignField' | 'localField' | 'joinRelation'
+'localField' | 'getRelationMetadata' | 'rootAlias'
 >> & {
-  linkParams?: boolean
+  linkParams?: boolean;
+  relationContext?: unknown;
 };
 
 export class Query {
@@ -25,20 +58,18 @@ export class Query {
   private _fieldPrefix!: string;
   private _params: unknown[] = [];
   private _sql: string[] = [];
-  private _joins = new Set<string>();
   private _lastPlaceholderIndex = 1;
-  private _relationContext!: unknown;
+  private _relationCounter = { value: 0 };
+  public readonly relationContext!: unknown;
+  public readonly rootAlias?: string;
   private _rootAlias!: string;
 
   constructor(options: SqlQueryOptions, fieldPrefix = '', relationContext?: unknown) {
     this.options = options;
     this._fieldPrefix = fieldPrefix;
-    this._relationContext = relationContext;
+    this.relationContext = relationContext;
+    this.rootAlias = options.rootAlias;
     this._rootAlias = options.rootAlias ? `${options.escapeField(options.rootAlias)}.` : '';
-
-    if (this.options.foreignField) {
-      this._foreignField = this.options.foreignField;
-    }
 
     if (this.options.localField) {
       this._localField = this.options.localField;
@@ -47,34 +78,15 @@ export class Query {
 
   field(rawName: string) {
     const name = this._fieldPrefix + rawName;
+    return this._rootAlias + this._localField(name);
+  }
 
-    if (!this.options.joinRelation) {
-      return this._rootAlias + this._localField(name);
-    }
-
-    const relationNameIndex = name.indexOf('.');
-
-    if (relationNameIndex === -1) {
-      return this._rootAlias + this._localField(name);
-    }
-
-    const relationName = name.slice(0, relationNameIndex);
-    const field = name.slice(relationNameIndex + 1);
-
-    if (!this.options.joinRelation(relationName, this._relationContext)) {
-      return this._rootAlias + this._localField(name);
-    }
-
-    this._joins.add(relationName);
-    return this._foreignField(field, relationName);
+  rootField(name: string) {
+    return this._rootAlias + this._localField(name);
   }
 
   private _localField(field: string) {
     return this.options.escapeField(field);
-  }
-
-  private _foreignField(field: string, relationName: string) {
-    return `${this.options.escapeField(relationName)}.${this.options.escapeField(field)}`;
   }
 
   param(value: unknown) {
@@ -87,6 +99,10 @@ export class Query {
     return items.map(item => this.param(item));
   }
 
+  nextRelationAlias(prefix: string) {
+    return `${prefix}_${this._relationCounter.value++}`;
+  }
+
   child(options?: ChildOptions) {
     let queryOptions: SqlQueryOptions = this.options;
     let canLinkParams = false;
@@ -97,11 +113,12 @@ export class Query {
       canLinkParams = !!linkParams;
     }
 
-    const query = new Query(queryOptions, this._fieldPrefix, this._relationContext);
+    const relationContext = options?.relationContext ?? this.relationContext;
+    const query = new Query(queryOptions, this._fieldPrefix, relationContext);
+    query._relationCounter = this._relationCounter;
 
     if (canLinkParams) {
       query._params = this._params;
-      query._joins = this._joins; // TODO: investigate case of referencing relations of relations
     } else {
       query._lastPlaceholderIndex = this._lastPlaceholderIndex + this._params.length;
     }
@@ -124,9 +141,6 @@ export class Query {
 
     if (this._params !== query._params) {
       this._params.push(...query._params);
-      for (const relation of query._joins) {
-        this._joins.add(relation);
-      }
     }
     return this;
   }
@@ -143,8 +157,8 @@ export class Query {
     }
   }
 
-  toJSON(): [string, unknown[], string[]] {
-    return [this._sql.join(' and '), this._params, Array.from(this._joins)];
+  toJSON(): [string, unknown[]] {
+    return [this._sql.join(' and '), this._params];
   }
 }
 

--- a/packages/sql/src/interpreters.ts
+++ b/packages/sql/src/interpreters.ts
@@ -4,13 +4,25 @@ import {
   type Condition,
   type Comparable
 } from '@ucast/core';
-import { type SqlOperator } from './interpreter.ts';
+import {
+  type CustomRelationMetadata,
+  type RelationMetadata,
+  type SimpleRelationMetadata,
+  type SqlOperator,
+  type Query
+} from './interpreter.ts';
 
 export const eq: SqlOperator<FieldCondition> = (condition, query) => {
+  if (condition.value === null) {
+    return query.whereRaw(`${query.field(condition.field)} is null`);
+  }
   return query.where(condition.field, '=', condition.value);
 };
 
 export const ne: typeof eq = (condition, query) => {
+  if (condition.value === null) {
+    return query.whereRaw(`${query.field(condition.field)} is not null`);
+  }
   return query.where(condition.field, '<>', condition.value);
 };
 
@@ -34,7 +46,7 @@ export const exists: SqlOperator<FieldCondition<Comparable>> = (condition, query
   return query.whereRaw(`${query.field(condition.field)} is ${condition.value ? 'not ' : ''}null`);
 };
 
-function manyParamsOperator(name: string): SqlOperator<FieldCondition<unknown[]>> {
+function manyParamsOperator(name: 'in' | 'not in'): SqlOperator<FieldCondition<unknown[]>> {
   return (condition, query) => {
     return query.whereRaw(
       `${query.field(condition.field)} ${name}(${query.manyParams(condition.value).join(', ')})`,
@@ -77,3 +89,125 @@ export const not = compoundOperator('and', true);
 export const and = compoundOperator('and');
 export const or = compoundOperator('or');
 export const nor = compoundOperator('or', true);
+
+export const someRelation = relationOperator(false, false);
+export const noneRelation = relationOperator(true, false);
+export const everyRelation = relationOperator(true, true);
+export const isRelation = someRelation;
+export const isNotRelation = noneRelation;
+
+function getRelationMetadata(query: Query, relationName: string) {
+  const escape = query.options.escapeField;
+  const relation = query.options.getRelationMetadata?.(
+    relationName,
+    {
+      escape,
+      relationContext: query.relationContext,
+    },
+  );
+  if (!relation) {
+    throw new Error(`Relation metadata for "${relationName}" not found`);
+  }
+
+  return relation;
+}
+
+function relationOperator(
+  isInverted: boolean,
+  invertCondition: boolean
+): SqlOperator<FieldCondition<Condition>> {
+  return (condition, query, { interpret }) => {
+    const relation = getRelationMetadata(query, condition.field);
+    const relationAlias = query.nextRelationAlias(condition.field);
+    const conditionSql = createRelationConditionSql(
+      condition,
+      query,
+      relation,
+      relationAlias,
+      invertCondition,
+      interpret,
+    );
+    const relationSql = buildRelationQuery(
+      query,
+      condition.field,
+      relation,
+      relationAlias,
+      conditionSql
+    );
+
+    return query.whereRaw(`${isInverted ? 'NOT ' : ''}EXISTS (${relationSql})`);
+  };
+}
+
+function createRelationConditionSql(
+  condition: FieldCondition<Condition>,
+  query: Query,
+  relation: RelationMetadata,
+  relationAlias: string,
+  shouldInvert: boolean,
+  interpret: (condition: Condition, query: Query) => Query,
+) {
+  let sql: string | undefined;
+
+  return () => {
+    if (sql !== undefined) {
+      return sql;
+    }
+
+    const childQuery = query.child({
+      linkParams: true,
+      rootAlias: relationAlias,
+      relationContext: relation.relationContext,
+    });
+
+    interpret(condition.value, childQuery);
+    const [whereSql] = childQuery.toJSON();
+    sql = shouldInvert ? `NOT (${whereSql})` : whereSql;
+    return sql;
+  };
+}
+
+function buildRelationQuery(
+  query: Query,
+  relationName: string,
+  relation: RelationMetadata,
+  relationAlias: string,
+  conditionSql: () => string,
+) {
+  const escapeField = query.options.escapeField;
+  const context = {
+    relationName,
+    relationAlias,
+    parentAlias: query.rootAlias,
+    escapeField,
+    parentField: (field: string) => query.rootField(field),
+    relationField: (field: string) => `${escapeField(relationAlias)}.${escapeField(field)}`,
+    conditionSql,
+    param: (value: unknown) => query.param(value),
+  };
+
+  if (isCustomRelationMetadata(relation)) {
+    return relation.buildRelationQuery(context);
+  }
+
+  return buildSimpleRelationQuery(relation, context);
+}
+
+function buildSimpleRelationQuery(
+  relation: SimpleRelationMetadata,
+  context: {
+    relationAlias: string;
+    escapeField(field: string): string;
+    parentField(field: string): string;
+    relationField(field: string): string;
+    conditionSql(): string;
+  },
+) {
+  return `SELECT 1 FROM ${context.escapeField(relation.relationTable)} as ${context.escapeField(context.relationAlias)}` +
+  ` WHERE ${context.parentField(relation.parentField)} = ${context.relationField(relation.relationField)}` +
+  ` AND (${context.conditionSql()})`;
+}
+
+function isCustomRelationMetadata(relation: RelationMetadata): relation is CustomRelationMetadata {
+  return typeof (relation as CustomRelationMetadata).buildRelationQuery === 'function';
+}

--- a/packages/sql/src/lib/mikro-orm.ts
+++ b/packages/sql/src/lib/mikro-orm.ts
@@ -1,33 +1,80 @@
-import { EntityMetadata } from '@mikro-orm/core';
+import { type EntityMetadata, type EntityProperty } from '@mikro-orm/core';
 import { type Condition } from '@ucast/core';
 import {
   allInterpreters,
   createDialects,
   createSqlInterpreter,
   mysql,
+  type SqlQueryOptions,
   type SqlOperator
-} from '../index';
+} from '../index.ts';
+import {
+  buildDirectRelationQuery,
+  buildManyToManyRelationQuery,
+  RelationColumnPair,
+  type ThroughRelationColumnPair,
+} from '../relationUtils.ts';
 
-function joinRelation(relationName: string, query: QueryBuilder) {
-  const privateQuery = query as any;
-  const meta = privateQuery.mainAlias.metadata as EntityMetadata;
-  const prop = meta.properties[relationName];
+type GetRelationMetadata = Exclude<SqlQueryOptions['getRelationMetadata'], undefined>;
 
-  if (prop?.ref) {
-    query.join(`${query.alias}.${relationName}`, relationName);
-    return true;
-  }
-
-  return false;
+export interface MikroOrmInterpreterOptions {
+  getRelationMetadata?: GetRelationMetadata;
 }
 
-const dialects = createDialects({
-  joinRelation,
-  paramPlaceholder: mysql.paramPlaceholder,
-});
+export const getRelationMetadata: GetRelationMetadata = (relationName, ctx) => {
+  const meta = getEntityMetadata(ctx.relationContext);
+  const prop = meta?.properties[relationName] as MikroOrmRelation | undefined;
 
-export function createInterpreter(interpreters: Record<string, SqlOperator<any>>) {
+  if (!prop?.targetMeta) {
+    return undefined;
+  }
+
+  if (prop.kind === 'm:n') {
+    return {
+      relationContext: prop.targetMeta,
+      buildRelationQuery: buildManyToManyRelationQuery(
+        prop.pivotTable || prop.pivotEntity,
+        prop.targetMeta.tableName,
+        joinColumnPairs(prop.joinColumns, prop.referencedColumnNames, primaryColumnNames(meta)),
+        joinColumnPairs(prop.inverseJoinColumns, primaryColumnNames(prop.targetMeta)),
+      ),
+    };
+  }
+
+  const columnPairs = directRelationColumnPairs(prop);
+
+  if (!columnPairs.length) {
+    return undefined;
+  }
+
+  if (columnPairs.length === 1) {
+    return {
+      parentField: columnPairs[0].parentField,
+      relationField: columnPairs[0].relationField,
+      relationTable: prop.targetMeta.tableName,
+      relationContext: prop.targetMeta,
+    };
+  }
+
+  return {
+    relationContext: prop.targetMeta,
+    buildRelationQuery: buildDirectRelationQuery(prop.targetMeta.tableName, columnPairs),
+  };
+};
+
+function createMikroOrmDialects(mikroOrmOptions: MikroOrmInterpreterOptions = {}) {
+  return createDialects({
+    getRelationMetadata: mikroOrmOptions.getRelationMetadata ?? getRelationMetadata,
+    paramPlaceholder: mysql.paramPlaceholder,
+  });
+}
+
+export function createInterpreter(
+  interpreters: Record<string, SqlOperator<any>>,
+  mikroOrmOptions: MikroOrmInterpreterOptions = {},
+) {
   const interpretSQL = createSqlInterpreter(interpreters);
+  const dialects = createMikroOrmDialects(mikroOrmOptions);
 
   return <T extends QueryBuilder>(condition: Condition, query: T) => {
     const platformName = (query as any).platform.constructor.name;
@@ -38,15 +85,80 @@ export function createInterpreter(interpreters: Record<string, SqlOperator<any>>
       throw new Error(`Unsupported database dialect: ${dialect}`);
     }
 
-    const [sql, params] = interpretSQL(condition, options, query);
+    const [sql, params] = interpretSQL(condition, {
+      ...options,
+      rootAlias: query.alias,
+    }, getEntityMetadata(query));
     return query.where(sql, params);
   };
 }
 
 export const interpret = createInterpreter(allInterpreters);
 
+function directRelationColumnPairs(prop: MikroOrmRelation): RelationColumnPair[] {
+  if (prop.kind === 'm:1' || (prop.owner && prop.joinColumns?.length)) {
+    return joinColumnPairs(
+      prop.joinColumns,
+      prop.referencedColumnNames,
+      primaryColumnNames(prop.targetMeta)
+    ).map(pair => ({
+      parentField: pair.throughField,
+      relationField: pair.relationField,
+    }));
+  }
+
+  const mappedBy = prop.targetMeta
+    .properties[prop.mappedBy as string] as MikroOrmRelation | undefined;
+
+  if (!mappedBy?.joinColumns?.length) {
+    return [];
+  }
+
+  return joinColumnPairs(
+    mappedBy.joinColumns,
+    mappedBy.referencedColumnNames,
+    primaryColumnNames(prop.targetMeta),
+  ).map(pair => ({
+    parentField: pair.relationField,
+    relationField: pair.throughField,
+  }));
+}
+
+function getEntityMetadata(context: unknown): EntityMetadata {
+  if (isEntityMetadata(context)) {
+    return context;
+  }
+
+  return (context as QueryBuilder).mainAlias!.metadata!;
+}
+
+function isEntityMetadata(context: unknown): context is EntityMetadata {
+  return !!(context as EntityMetadata | undefined)?.properties;
+}
+
+function joinColumnPairs(
+  joinColumns: readonly string[],
+  referencedColumns: readonly string[],
+  fallbackReferencedColumns: readonly string[] = [],
+): ThroughRelationColumnPair[] {
+  return joinColumns.map((joinField, index) => ({
+    throughField: joinField,
+    relationField: referencedColumns[index] ?? fallbackReferencedColumns[index],
+  }));
+}
+
+function primaryColumnNames(meta: EntityMetadata) {
+  return meta.primaryKeys.map(key => meta.properties[key].fieldNames[0]);
+}
+
 interface QueryBuilder {
   alias: string;
-  join(path: string, alias: string): this;
+  mainAlias?: {
+    metadata?: EntityMetadata;
+  };
   where(sql: string, params?: unknown[]): this;
 }
+
+type MikroOrmRelation = EntityProperty & {
+  targetMeta: EntityMetadata;
+};

--- a/packages/sql/src/lib/objection.ts
+++ b/packages/sql/src/lib/objection.ts
@@ -1,29 +1,82 @@
 import { type Condition } from '@ucast/core';
-import { type Model, type QueryBuilder } from 'objection';
+import { type Model, type ModelClass, type QueryBuilder } from 'objection';
 import {
   createSqlInterpreter,
   allInterpreters,
   type SqlOperator,
   createDialects,
   mysql,
-} from '../index';
+  type SqlQueryOptions,
+} from '../index.ts';
+import {
+  buildDirectRelationQuery,
+  buildManyToManyRelationQuery,
+  RelationColumnPair,
+} from '../relationUtils.ts';
 
-function joinRelation(relationName: string, query: QueryBuilder<Model>) {
-  if (!query.modelClass().getRelation(relationName)) {
-    return false;
-  }
+type GetRelationMetadata = Exclude<SqlQueryOptions['getRelationMetadata'], undefined>;
 
-  query.joinRelated(relationName);
-  return true;
+export interface ObjectionInterpreterOptions {
+  getRelationMetadata?: GetRelationMetadata;
 }
 
-const dialects = createDialects({
-  joinRelation,
-  paramPlaceholder: mysql.paramPlaceholder,
-});
+export const getRelationMetadata: GetRelationMetadata = (relationName, ctx) => {
+  const Model = ctx.relationContext as ModelClass<Model>;
+  const relation = Model.getRelation(relationName) as RuntimeRelation | undefined;
 
-export function createInterpreter(interpreters: Record<string, SqlOperator<any>>) {
+  if (!relation) {
+    return undefined;
+  }
+
+  if (relation.joinTable) {
+    return {
+      relationContext: relation.relatedModelClass,
+      buildRelationQuery: buildManyToManyRelationQuery(
+        relation.joinTable,
+        relation.relatedModelClass.tableName,
+        throughColumnPairs(relation.ownerProp.cols, relation.joinTableOwnerProp.cols),
+        throughColumnPairs(relation.relatedProp.cols, relation.joinTableRelatedProp.cols),
+      ),
+    };
+  }
+
+  const columnPairs: RelationColumnPair[] = relation.ownerProp.cols.map((localField, index) => ({
+    parentField: localField,
+    relationField: relation.relatedProp.cols[index],
+  }));
+
+  if (columnPairs.length === 1) {
+    return {
+      parentField: columnPairs[0].parentField,
+      relationField: columnPairs[0].relationField,
+      relationTable: relation.relatedModelClass.tableName,
+      relationContext: relation.relatedModelClass,
+    };
+  }
+
+  return {
+    relationContext: relation.relatedModelClass,
+    buildRelationQuery: buildDirectRelationQuery(
+      relation.relatedModelClass.tableName,
+      columnPairs,
+    ),
+  };
+};
+
+function createObjectionDialects(objectionOptions: ObjectionInterpreterOptions = {}) {
+  return createDialects({
+    getRelationMetadata: objectionOptions.getRelationMetadata ?? getRelationMetadata,
+    paramPlaceholder: mysql.paramPlaceholder,
+  });
+}
+
+export function createInterpreter(
+  interpreters: Record<string, SqlOperator<any>>,
+  objectionOptions: ObjectionInterpreterOptions = {},
+) {
   const interpretSQL = createSqlInterpreter(interpreters);
+  const dialects = createObjectionDialects(objectionOptions);
+
   return <T extends Model>(condition: Condition, query: QueryBuilder<T>) => {
     const dialect = query.modelClass().knex().client.config.client as keyof typeof dialects;
     const options = dialects[dialect];
@@ -32,9 +85,41 @@ export function createInterpreter(interpreters: Record<string, SqlOperator<any>>
       throw new Error('Unsupported database dialect');
     }
 
-    const [sql, params] = interpretSQL(condition, options, query);
+    const [sql, params] = interpretSQL(condition, {
+      ...options,
+      rootAlias: getRootAlias(query),
+    }, query.modelClass());
     return query.whereRaw(sql, params);
   };
 }
 
 export const interpret = createInterpreter(allInterpreters);
+
+function getRootAlias<T extends Model>(query: QueryBuilder<T>) {
+  const queryWithTableRefs = query as QueryBuilder<T> & {
+    tableRefFor?(modelClass: ModelClass<Model>): string | undefined;
+  };
+
+  return queryWithTableRefs.tableRefFor?.(query.modelClass()) ?? query.modelClass().tableName;
+}
+
+function throughColumnPairs(relationFields: string[], throughFields: string[]) {
+  return relationFields.map((field, index) => ({
+    relationField: field,
+    throughField: throughFields[index],
+  }));
+}
+
+interface RuntimeRelation {
+  ownerProp: RelationProperty;
+  relatedProp: RelationProperty;
+  ownerModelClass: ModelClass<Model>;
+  relatedModelClass: ModelClass<Model>;
+  joinTable?: string;
+  joinTableOwnerProp: RelationProperty;
+  joinTableRelatedProp: RelationProperty;
+}
+
+interface RelationProperty {
+  cols: string[];
+}

--- a/packages/sql/src/lib/sequelize.ts
+++ b/packages/sql/src/lib/sequelize.ts
@@ -1,30 +1,86 @@
 import { type Condition } from '@ucast/core';
-import { type ModelStatic, Utils, literal } from 'sequelize';
+import { type Association, type ModelStatic, Utils, literal } from 'sequelize';
 import {
   createSqlInterpreter,
   allInterpreters,
   type SqlOperator,
   createDialects,
-  mysql
-} from '../index';
+  mysql,
+  type SqlQueryOptions,
+} from '../index.ts';
+import { buildManyToManyRelationQuery } from '../relationUtils.ts';
 
 const hasOwn: (object: object, key: PropertyKey) => boolean = (Object as {
   hasOwn?: (object: object, key: PropertyKey) => boolean
 }).hasOwn || ((object, key) => Object.prototype.hasOwnProperty.call(object, key));
 
-function joinRelation(relationName: string, Model: ModelStatic<any>) {
-  return hasOwn(Model.associations, relationName);
+type GetRelationMetadata = Exclude<SqlQueryOptions['getRelationMetadata'], undefined>;
+
+export interface SequelizeInterpreterOptions {
+  getRelationMetadata?: GetRelationMetadata;
 }
 
-const dialects = createDialects({
-  joinRelation,
-  paramPlaceholder: mysql.paramPlaceholder,
-});
+export const getRelationMetadata: GetRelationMetadata = (
+  relationName,
+  ctx,
+) => {
+  const Model = ctx.relationContext as ModelStatic<any>;
+  if (!hasOwn(Model.associations, relationName)) return;
 
-export function createInterpreter(interpreters: Record<string, SqlOperator<any>>) {
+  const association = Model.associations[relationName] as RuntimeAssociation;
+
+  if (association.associationType === 'BelongsTo') {
+    return {
+      parentField: association.identifierField,
+      relationField: association.targetKeyField,
+      relationTable: association.target.tableName,
+      relationContext: association.target,
+    };
+  }
+
+  if (association.associationType === 'HasOne' || association.associationType === 'HasMany') {
+    return {
+      parentField: association.sourceKeyField,
+      relationField: association.identifierField,
+      relationTable: association.target.tableName,
+      relationContext: association.target,
+    };
+  }
+
+  if (association.associationType === 'BelongsToMany') {
+    const throughTable = association.throughModel?.tableName ?? association.through.model.tableName;
+
+    return {
+      relationContext: association.target,
+      buildRelationQuery: buildManyToManyRelationQuery(
+        throughTable,
+        association.target.tableName,
+        [{
+          relationField: association.sourceKeyField,
+          throughField: association.identifierField,
+        }],
+        [{
+          relationField: association.targetKeyField,
+          throughField: association.foreignIdentifierField,
+        }],
+      ),
+    };
+  }
+
+  return undefined;
+};
+
+export function createInterpreter(
+  interpreters: Record<string, SqlOperator<any>>,
+  sequelizeOptions: SequelizeInterpreterOptions = {},
+) {
   const interpretSQL = createSqlInterpreter(interpreters);
+  const dialects = createDialects({
+    getRelationMetadata: sequelizeOptions.getRelationMetadata ?? getRelationMetadata,
+    paramPlaceholder: mysql.paramPlaceholder,
+  });
 
-  return (condition: Condition, Model: ModelStatic<any>) => {
+  return (condition: Condition, Model: ModelStatic<any>, callOptions?: { rootAlias?: string }) => {
     const dialect = Model.sequelize!.getDialect() as keyof typeof dialects;
     const options = dialects[dialect];
 
@@ -32,12 +88,41 @@ export function createInterpreter(interpreters: Record<string, SqlOperator<any>>
       throw new Error(`Unsupported database dialect: ${dialect}`);
     }
 
-    const [sql, params, joins] = interpretSQL(condition, options, Model);
+    const [sql, params] = interpretSQL(condition, {
+      ...options,
+      rootAlias: callOptions?.rootAlias ?? Model.tableName
+    }, Model);
     return {
-      include: joins.map(association => ({ association, required: true })),
       where: literal(Utils.format([sql, ...(params as string[])], dialect)),
     };
   };
 }
 
 export const interpret = createInterpreter(allInterpreters);
+
+type BelongsToAssociation = Association & {
+  associationType: 'BelongsTo';
+  target: ModelStatic<any>;
+  identifierField: string;
+  targetKeyField: string;
+};
+
+type HasAssociation = Association & {
+  associationType: 'HasOne' | 'HasMany';
+  target: ModelStatic<any>;
+  identifierField: string;
+  sourceKeyField: string;
+};
+
+type BelongsToManyAssociation = Association & {
+  associationType: 'BelongsToMany';
+  target: ModelStatic<any>;
+  through: { model: ModelStatic<any> };
+  throughModel?: ModelStatic<any>;
+  identifierField: string;
+  foreignIdentifierField: string;
+  sourceKeyField: string;
+  targetKeyField: string;
+};
+
+type RuntimeAssociation = BelongsToAssociation | HasAssociation | BelongsToManyAssociation;

--- a/packages/sql/src/lib/typeorm.ts
+++ b/packages/sql/src/lib/typeorm.ts
@@ -1,43 +1,83 @@
 import { type Condition } from '@ucast/core';
-import { type ObjectLiteral, type SelectQueryBuilder } from 'typeorm';
+import { type EntityMetadata, type ObjectLiteral, type SelectQueryBuilder } from 'typeorm';
 import {
   createSqlInterpreter,
   allInterpreters,
   type SqlOperator,
-  createDialects
-} from '../index';
+  createDialects,
+  type SqlQueryOptions
+} from '../index.ts';
+import {
+  buildDirectRelationQuery,
+  buildManyToManyRelationQuery,
+  RelationColumnPair,
+  type ThroughRelationColumnPair,
+} from '../relationUtils.ts';
 
-function joinRelation<Entity extends ObjectLiteral>(
-  relationName: string,
-  query: SelectQueryBuilder<Entity>,
-) {
-  const meta = query.expressionMap.mainAlias!.metadata;
-  const joinAlreadyExists = query.expressionMap.joinAttributes
-    .some(j => j.alias.name === relationName);
+type GetRelationMetadata = Exclude<SqlQueryOptions['getRelationMetadata'], undefined>;
 
-  if (joinAlreadyExists) {
-    return true;
-  }
-
-  const relation = meta.findRelationWithPropertyPath(relationName);
-  if (relation) {
-    query.innerJoin(`${query.alias}.${relationName}`, relationName);
-    return true;
-  }
-
-  return false;
+export interface TypeOrmInterpreterOptions {
+  getRelationMetadata?: GetRelationMetadata;
 }
 
-const dialects = createDialects({
-  joinRelation,
-  paramPlaceholder: index => `:${index - 1}`
-});
+export const getRelationMetadata: GetRelationMetadata = (relationName, ctx) => {
+  const meta = getEntityMetadata(ctx.relationContext);
+  const relation = meta?.findRelationWithPropertyPath(relationName) as TypeOrmRelation | undefined;
 
+  if (!relation) {
+    return undefined;
+  }
 
-dialects.sqlite.escapeField = dialects.sqlite3.escapeField = dialects.pg.escapeField;
+  if (relation.isManyToMany) {
+    return buildManyToManyRelationMetadata(relation);
+  }
 
-export function createInterpreter(interpreters: Record<string, SqlOperator<any>>) {
+  const isOwningSide = relation.joinColumns.length > 0;
+  const joinColumns = isOwningSide ? relation.joinColumns : relation.inverseRelation?.joinColumns;
+
+  if (!joinColumns?.length) {
+    return undefined;
+  }
+
+  const columnPairs: RelationColumnPair[] = joinColumns.map(column => ({
+    parentField: isOwningSide ? column.databaseName : column.referencedColumn!.databaseName,
+    relationField: isOwningSide ? column.referencedColumn!.databaseName : column.databaseName,
+  }));
+
+  if (columnPairs.length === 1) {
+    return {
+      parentField: columnPairs[0].parentField,
+      relationField: columnPairs[0].relationField,
+      relationTable: relation.inverseEntityMetadata.tableName,
+      relationContext: relation.inverseEntityMetadata,
+    };
+  }
+
+  return {
+    relationContext: relation.inverseEntityMetadata,
+    buildRelationQuery: buildDirectRelationQuery(
+      relation.inverseEntityMetadata.tableName,
+      columnPairs,
+    ),
+  };
+};
+
+function createTypeOrmDialects(typeormOptions: TypeOrmInterpreterOptions = {}) {
+  const dialects = createDialects({
+    getRelationMetadata: typeormOptions.getRelationMetadata ?? getRelationMetadata,
+    paramPlaceholder: index => `:${index - 1}`
+  });
+
+  dialects.sqlite.escapeField = dialects.sqlite3.escapeField = dialects.pg.escapeField;
+  return dialects;
+}
+
+export function createInterpreter(
+  interpreters: Record<string, SqlOperator<any>>,
+  typeormOptions: TypeOrmInterpreterOptions = {},
+) {
   const interpretSQL = createSqlInterpreter(interpreters);
+  const dialects = createTypeOrmDialects(typeormOptions);
 
   return <Entity extends ObjectLiteral>(
     condition: Condition,
@@ -50,9 +90,71 @@ export function createInterpreter(interpreters: Record<string, SqlOperator<any>>
       throw new Error(`Unsupported database dialect: ${dialect}`);
     }
 
-    const [sql, params] = interpretSQL(condition, options, query);
+    const [sql, params] = interpretSQL(condition, {
+      ...options,
+      rootAlias: query.alias,
+    }, query.expressionMap.mainAlias!.metadata);
     return query.where(sql, params);
   };
 }
 
 export const interpret = createInterpreter(allInterpreters);
+
+function buildManyToManyRelationMetadata(relation: TypeOrmRelation) {
+  const ownerRelation = relation.isOwning ? relation : relation.inverseRelation;
+
+  if (!ownerRelation?.junctionEntityMetadata) {
+    return undefined;
+  }
+
+  const localColumns = relation.isOwning
+    ? ownerRelation.joinColumns
+    : ownerRelation.inverseJoinColumns;
+  const foreignColumns = relation.isOwning
+    ? ownerRelation.inverseJoinColumns
+    : ownerRelation.joinColumns;
+
+  return {
+    relationContext: relation.inverseEntityMetadata,
+    buildRelationQuery: buildManyToManyRelationQuery(
+      ownerRelation.junctionEntityMetadata.tableName,
+      relation.inverseEntityMetadata.tableName,
+      localColumns.map(toJoinColumnPair),
+      foreignColumns.map(toJoinColumnPair),
+    ),
+  };
+}
+
+function getEntityMetadata(context: unknown) {
+  if (isEntityMetadata(context)) {
+    return context;
+  }
+
+  return (context as SelectQueryBuilder<ObjectLiteral>).expressionMap?.mainAlias?.metadata;
+}
+
+function isEntityMetadata(context: unknown): context is EntityMetadata {
+  return typeof (context as EntityMetadata | undefined)?.findRelationWithPropertyPath === 'function';
+}
+
+function toJoinColumnPair(column: TypeOrmColumn): ThroughRelationColumnPair {
+  return {
+    throughField: column.databaseName,
+    relationField: column.referencedColumn!.databaseName,
+  };
+}
+
+interface TypeOrmRelation {
+  inverseEntityMetadata: EntityMetadata;
+  inverseRelation?: TypeOrmRelation;
+  isManyToMany: boolean;
+  isOwning: boolean;
+  joinColumns: TypeOrmColumn[];
+  inverseJoinColumns: TypeOrmColumn[];
+  junctionEntityMetadata?: EntityMetadata;
+}
+
+interface TypeOrmColumn {
+  databaseName: string;
+  referencedColumn?: TypeOrmColumn;
+}

--- a/packages/sql/src/relationUtils.ts
+++ b/packages/sql/src/relationUtils.ts
@@ -1,0 +1,50 @@
+import { type RelationQueryContext } from './interpreter.ts';
+
+export interface RelationColumnPair {
+  parentField: string;
+  relationField: string;
+}
+
+export interface ThroughRelationColumnPair {
+  relationField: string;
+  throughField: string;
+}
+
+export function buildDirectRelationQuery(
+  relationTable: string,
+  columnPairs: readonly RelationColumnPair[],
+) {
+  return (ctx: RelationQueryContext) => {
+    const relationConditions = columnPairs
+      .map(pair => `${ctx.parentField(pair.parentField)} = ${ctx.relationField(pair.relationField)}`)
+      .join(' AND ');
+
+    return `SELECT 1 FROM ${ctx.escapeField(relationTable)} as ${ctx.escapeField(ctx.relationAlias)}` +
+      ` WHERE ${relationConditions}` +
+      ` AND (${ctx.conditionSql()})`;
+  };
+}
+
+export function buildManyToManyRelationQuery(
+  throughTable: string,
+  foreignTable: string,
+  localColumns: readonly ThroughRelationColumnPair[],
+  foreignColumns: readonly ThroughRelationColumnPair[],
+) {
+  return (ctx: RelationQueryContext) => {
+    const throughAlias = ctx.escapeField(`${ctx.relationAlias}_through`);
+    const throughField = (field: string) => `${throughAlias}.${ctx.escapeField(field)}`;
+    const joinConditions = foreignColumns
+      .map(column => `${ctx.relationField(column.relationField)} = ${throughField(column.throughField)}`)
+      .join(' AND ');
+    const whereConditions = localColumns
+      .map(column => `${ctx.parentField(column.relationField)} = ${throughField(column.throughField)}`)
+      .join(' AND ');
+
+    return `SELECT 1 FROM ${ctx.escapeField(throughTable)} as ${throughAlias}` +
+      ` INNER JOIN ${ctx.escapeField(foreignTable)} as ${ctx.escapeField(ctx.relationAlias)}` +
+      ` ON ${joinConditions}` +
+      ` WHERE ${whereConditions}` +
+      ` AND (${ctx.conditionSql()})`;
+  };
+}

--- a/packages/sql/tsconfig.json
+++ b/packages/sql/tsconfig.json
@@ -1,13 +1,15 @@
 {
   "extends": "../../tsconfig",
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "spec/**/*"
   ],
   "compilerOptions": {
     "outDir": "dist/types",
-    "rootDir": "src",
+    "rootDir": ".",
     "rewriteRelativeImportExtensions": false,
     "allowImportingTsExtensions": true,
-    "allowJs": true
+    "allowJs": true,
+    "types": ["node", "mocha", "chai"]
   }
 }

--- a/packages/sql/typeorm/package.json
+++ b/packages/sql/typeorm/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "@ucast/sql-typeorm",
-  "private": true,
-  "typings": "../dist/types/lib/typeorm.d.ts",
-  "main": "../dist/cjs/lib/typeorm.js",
-  "es2015": "../dist/esm/lib/typeorm.mjs"
-}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 packages:
   - packages/*
 
+allowBuilds:
+  sqlite3: true
+
 minimumReleaseAge: 10080
 
 onlyBuiltDependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "strict": true,
     "declaration": true,
     "emitDeclarationOnly": true,


### PR DESCRIPTION
## What

Add relation operators for SQL interpreters and switch ORM adapters to build relation filters from `getRelationMetadata` instead of implicit dot-join logic. Support simple relations, custom relation SQL, nested relations, and through-table many-to-many relations across Sequelize, TypeORM, MikroORM, and Objection.

BREAKING CHANGE: Relation filtering no longer uses dotted field names to trigger ORM joins. Use relation operators such as `some`, `none`, or `every` and provide relation metadata with `getRelationMetadata` when needed.

**Before**:

```ts
const condition = new FieldCondition(
  'eq',
  'projects.name',
  'Audit',
)

interpret(condition, User.query())
```

**After**:

```ts
const condition = new FieldCondition(
  'some',
  'projects',
  new FieldCondition('eq', 'name', 'Audit'),
)

interpret(condition, User.query())
```